### PR TITLE
Fix: Menu music now correctly stops on race start and resumes on return.

### DIFF
--- a/top_speed_net/TopSpeed/Core/Game.cs
+++ b/top_speed_net/TopSpeed/Core/Game.cs
@@ -786,6 +786,8 @@ namespace TopSpeed.Core
 
         private void StartRace(RaceMode mode)
         {
+            _menu.StopAllMusic();
+
             var track = string.IsNullOrWhiteSpace(_setup.TrackNameOrFile)
                 ? RaceTracks[0].Key
                 : _setup.TrackNameOrFile!;

--- a/top_speed_net/TopSpeed/Menu/MenuManager.cs
+++ b/top_speed_net/TopSpeed/Menu/MenuManager.cs
@@ -33,6 +33,7 @@ namespace TopSpeed.Menu
             var screen = GetScreen(id);
             screen.ResetSelection();
             screen.Initialize();
+            screen.PlayMusic();
             _stack.Push(screen);
             screen.AnnounceTitle();
         }
@@ -42,6 +43,7 @@ namespace TopSpeed.Menu
             var screen = GetScreen(id);
             screen.ResetSelection();
             screen.Initialize();
+            screen.PlayMusic();
             _stack.Push(screen);
             screen.AnnounceTitle();
         }
@@ -100,6 +102,14 @@ namespace TopSpeed.Menu
             if (!_screens.TryGetValue(id, out var screen))
                 throw new InvalidOperationException($"Menu not registered: {id}");
             return screen;
+        }
+
+        public void StopAllMusic()
+        {
+            foreach (var screen in _stack)
+            {
+                screen.StopMusic();
+            }
         }
 
         public void Dispose()

--- a/top_speed_net/TopSpeed/Menu/MenuScreen.cs
+++ b/top_speed_net/TopSpeed/Menu/MenuScreen.cs
@@ -89,11 +89,20 @@ namespace TopSpeed.Menu
                 {
                     _music = _audio.CreateSource(themePath, streamFromDisk: true);
                     _music.SetVolume(_musicVolume);
-                    _music.Play(loop: true);
+                    PlayMusic();
                 }
             }
 
             _initialized = true;
+        }
+
+        public void PlayMusic()
+        {
+            if (_music == null)
+                return;
+
+            _music.SeekToStart();
+            _music.Play(loop: true);
         }
 
         public MenuUpdateResult Update(InputManager input)
@@ -319,6 +328,11 @@ namespace TopSpeed.Menu
             sound.Play(loop: false);
         }
 
+        public void StopMusic()
+        {
+            _music?.Stop();
+        }
+
         public void Dispose()
         {
             foreach (var item in _items)
@@ -326,6 +340,7 @@ namespace TopSpeed.Menu
             _navigateSound?.Dispose();
             _wrapSound?.Dispose();
             _activateSound?.Dispose();
+            _music?.Stop();
             _music?.Dispose();
         }
     }


### PR DESCRIPTION
Previously, menu background music would continue playing when a race was initiated, creating an auditory conflict. Additionally, when returning to the main menu after a race, the music would not restart. This commit resolves both issues by ensuring:
- Menu music is stopped precisely when any race (Quick Start, Time Trial, Single Race) begins.
- Menu music correctly resumes playback when navigating back to a menu screen.

# Conflicts:
#	top_speed_net/TopSpeed/Core/Game.cs
#	top_speed_net/TopSpeed/Menu/MenuManager.cs
#	top_speed_net/TopSpeed/Menu/MenuScreen.cs