### PR TITLE
Add Stereo Widening option for player vehicle (works with HRTF on or off)

### DIFF
--- a/top_speed_net/TS.Audio/AudioSourceHandle.cs
+++ b/top_speed_net/TS.Audio/AudioSourceHandle.cs
@@ -25,6 +25,7 @@ namespace TS.Audio
         public float TransLow = 0.0f;
         public float TransMid = 0.0f;
         public float TransHigh = 0.0f;
+        public bool StereoWidening = false;
         public int SimulationFlags = 0;
         public float ReverbTimeLow = 0.0f;
         public float ReverbTimeMid = 0.0f;
@@ -273,6 +274,11 @@ namespace TS.Audio
         {
             _basePitch = pitch;
             _sound.SetPitch(pitch);
+        }
+
+        public void SetStereoWidening(bool enabled)
+        {
+            _spatial.StereoWidening = enabled;
         }
 
         public float GetPitch()

--- a/top_speed_net/TS.Audio/SteamAudioSpatializer.cs
+++ b/top_speed_net/TS.Audio/SteamAudioSpatializer.cs
@@ -234,15 +234,37 @@ namespace TS.Audio
                 IPL.BinauralEffectApply(_binauralRight, ref binauralParams, ref dirBufferR, ref outBufferR);
 
                 const float mixScale = 0.5f;
-                for (int i = 0; i < frames; i++)
+
+                if (spatial.StereoWidening)
                 {
-                    int idx = i * (int)channels;
-                    float left = (pOutLL[i] + pOutRL[i]) * mixScale;
-                    float right = (pOutLR[i] + pOutRR[i]) * mixScale;
-                    framesOut[idx] = left;
-                    framesOut[idx + 1] = right;
-                    for (int ch = 2; ch < channels; ch++)
-                        framesOut[idx + ch] = 0f;
+                    // Apply channel-specific attenuation based on the sound's horizontal direction (X-axis).
+                    // A buffer is included to ensure complete silence is only reached at the maximum extent of the arc.
+                    float x = direction.X;
+                    float leftGain = x > 0f ? Math.Max(0f, 1.0f - (x / 0.90f)) : 1.0f;
+                    float rightGain = x < 0f ? Math.Max(0f, 1.0f + (x / 0.90f)) : 1.0f;
+
+                    for (int i = 0; i < frames; i++)
+                    {
+                        int idx = i * (int)channels;
+                        framesOut[idx] = (pOutLL[i] + pOutRL[i]) * mixScale * leftGain;
+                        framesOut[idx + 1] = (pOutLR[i] + pOutRR[i]) * mixScale * rightGain;
+                        for (int ch = 2; ch < channels; ch++)
+                            framesOut[idx + ch] = 0f;
+                    }
+                }
+                else
+                {
+                    // EXACT Vanilla Path
+                    for (int i = 0; i < frames; i++)
+                    {
+                        int idx = i * (int)channels;
+                        float left = (pOutLL[i] + pOutRL[i]) * mixScale;
+                        float right = (pOutLR[i] + pOutRR[i]) * mixScale;
+                        framesOut[idx] = left;
+                        framesOut[idx + 1] = right;
+                        for (int ch = 2; ch < channels; ch++)
+                            framesOut[idx + ch] = 0f;
+                    }
                 }
 
                 if ((simFlags & AudioSourceSpatialParams.SimReflections) != 0)
@@ -380,14 +402,36 @@ namespace TS.Audio
                 IPL.DirectEffectApply(_directLeft, ref directParams, ref inputBuffer, ref inputBuffer);
                 IPL.BinauralEffectApply(_binauralLeft, ref binauralParams, ref inputBuffer, ref outputBuffer);
 
-                for (int i = 0; i < frames; i++)
+                if (spatial.StereoWidening)
                 {
-                    int idx = i * (int)channels;
-                    framesOut[idx] = pOutL[i];
-                    if (channels > 1)
-                        framesOut[idx + 1] = pOutR[i];
-                    for (int ch = 2; ch < channels; ch++)
-                        framesOut[idx + ch] = 0f;
+                    // Apply channel-specific attenuation based on the sound's horizontal direction (X-axis).
+                    // A buffer is included to ensure complete silence is only reached at the maximum extent of the arc.
+                    float x = direction.X;
+                    float leftGain = x > 0f ? Math.Max(0f, 1.0f - (x / 0.90f)) : 1.0f;
+                    float rightGain = x < 0f ? Math.Max(0f, 1.0f + (x / 0.90f)) : 1.0f;
+
+                    for (int i = 0; i < frames; i++)
+                    {
+                        int idx = i * (int)channels;
+                        framesOut[idx] = pOutL[i] * leftGain;
+                        if (channels > 1)
+                            framesOut[idx + 1] = pOutR[i] * rightGain;
+                        for (int ch = 2; ch < channels; ch++)
+                            framesOut[idx + ch] = 0f;
+                    }
+                }
+                else
+                {
+                    // EXACT Vanilla Path
+                    for (int i = 0; i < frames; i++)
+                    {
+                        int idx = i * (int)channels;
+                        framesOut[idx] = pOutL[i];
+                        if (channels > 1)
+                            framesOut[idx + 1] = pOutR[i];
+                        for (int ch = 2; ch < channels; ch++)
+                            framesOut[idx + ch] = 0f;
+                    }
                 }
 
                 if ((simFlags & AudioSourceSpatialParams.SimReflections) != 0)

--- a/top_speed_net/TopSpeed/Core/Settings/Contracts.cs
+++ b/top_speed_net/TopSpeed/Core/Settings/Contracts.cs
@@ -64,6 +64,9 @@ namespace TopSpeed.Core.Settings
         [DataMember(Name = "hrtfAudio")]
         public bool? HrtfAudio { get; set; }
 
+        [DataMember(Name = "stereoWidening")]
+        public bool? StereoWidening { get; set; }
+
         [DataMember(Name = "autoDetectAudioDeviceFormat")]
         public bool? AutoDetectAudioDeviceFormat { get; set; }
     }

--- a/top_speed_net/TopSpeed/Core/Settings/SettingsManager.Apply.cs
+++ b/top_speed_net/TopSpeed/Core/Settings/SettingsManager.Apply.cs
@@ -98,6 +98,9 @@ namespace TopSpeed.Core.Settings
             if (audio.HrtfAudio.HasValue)
                 settings.HrtfAudio = audio.HrtfAudio.Value;
 
+            if (audio.StereoWidening.HasValue)
+                settings.StereoWidening = audio.StereoWidening.Value;
+
             if (audio.AutoDetectAudioDeviceFormat.HasValue)
                 settings.AutoDetectAudioDeviceFormat = audio.AutoDetectAudioDeviceFormat.Value;
 

--- a/top_speed_net/TopSpeed/Core/Settings/SettingsManager.Serialization.cs
+++ b/top_speed_net/TopSpeed/Core/Settings/SettingsManager.Serialization.cs
@@ -158,6 +158,7 @@ namespace TopSpeed.Core.Settings
                     MusicPercent = audio.MusicPercent,
                     OnlineServerEventsPercent = audio.OnlineServerEventsPercent,
                     HrtfAudio = settings.HrtfAudio,
+                    StereoWidening = settings.StereoWidening,
                     AutoDetectAudioDeviceFormat = settings.AutoDetectAudioDeviceFormat
                 },
                 Input = new SettingsInputDocument

--- a/top_speed_net/TopSpeed/Input/Settings/RaceSettings.cs
+++ b/top_speed_net/TopSpeed/Input/Settings/RaceSettings.cs
@@ -64,6 +64,7 @@ namespace TopSpeed.Input
         public float MusicVolume { get; set; }
         public AudioVolumeSettings AudioVolumes { get; set; } = new AudioVolumeSettings();
         public bool HrtfAudio { get; set; }
+        public bool StereoWidening { get; set; }
         public bool AutoDetectAudioDeviceFormat { get; set; }
         public bool RandomCustomTracks { get; set; }
         public bool RandomCustomVehicles { get; set; }
@@ -138,6 +139,7 @@ namespace TopSpeed.Input
             AudioVolumes = new AudioVolumeSettings();
             AudioVolumes.RestoreDefaults((int)Math.Round(MusicVolume * 100f));
             HrtfAudio = true;
+            StereoWidening = false;
             AutoDetectAudioDeviceFormat = true;
             RandomCustomTracks = false;
             RandomCustomVehicles = false;

--- a/top_speed_net/TopSpeed/Menu/registry/options/Game.cs
+++ b/top_speed_net/TopSpeed/Menu/registry/options/Game.cs
@@ -27,6 +27,11 @@ namespace TopSpeed.Menu
                     value => _settingsActions.UpdateSetting(() => _settings.HrtfAudio = value),
                     hint: "When checked, Three-D audio uses HRTF spatialization for more realistic positioning. Press ENTER to toggle."),
                 new CheckBox(
+                    "Enable stereo widening for own car",
+                    () => _settings.StereoWidening,
+                    value => _settingsActions.UpdateSetting(() => _settings.StereoWidening = value),
+                    hint: "When checked, the game will widen the stereo image of your own car's sounds and quiet the opposite ear as you move. Press ENTER to toggle."),
+                new CheckBox(
                     "Automatic audio device format",
                     () => _settings.AutoDetectAudioDeviceFormat,
                     value => _settingsActions.UpdateSetting(() => _settings.AutoDetectAudioDeviceFormat = value),

--- a/top_speed_net/TopSpeed/Vehicles/Audio/Init.cs
+++ b/top_speed_net/TopSpeed/Vehicles/Audio/Init.cs
@@ -79,6 +79,27 @@ namespace TopSpeed.Vehicles
             _soundMiniCrash.SetDopplerFactor(0f);
             _soundBump.SetDopplerFactor(0f);
             _soundWipers?.SetDopplerFactor(0f);
+
+            if (_settings.StereoWidening)
+            {
+                _soundEngine.SetStereoWidening(true);
+                _soundThrottle?.SetStereoWidening(true);
+                _soundHorn.SetStereoWidening(true);
+                _soundBrake.SetStereoWidening(true);
+                for (var i = 0; i < _soundCrashVariants.Length; i++) _soundCrashVariants[i].SetStereoWidening(true);
+                for (var i = 0; i < _soundBackfireVariants.Length; i++) _soundBackfireVariants[i].SetStereoWidening(true);
+                _soundStart.SetStereoWidening(true);
+                _soundMiniCrash.SetStereoWidening(true);
+                _soundBump.SetStereoWidening(true);
+                _soundBadSwitch.SetStereoWidening(true);
+                _soundWipers?.SetStereoWidening(true);
+                _soundAsphalt.SetStereoWidening(true);
+                _soundGravel.SetStereoWidening(true);
+                _soundWater.SetStereoWidening(true);
+                _soundSand.SetStereoWidening(true);
+                _soundSnow.SetStereoWidening(true);
+            }
+
             RefreshCategoryVolumes(force: true);
         }
     }

--- a/top_speed_net/TopSpeed/Vehicles/Spatial/Spatial.cs
+++ b/top_speed_net/TopSpeed/Vehicles/Spatial/Spatial.cs
@@ -73,6 +73,8 @@ namespace TopSpeed.Vehicles
             // Maps the sound to a 180-degree arc relative to the listener.
             var angle = normalized * (float)(Math.PI / 2.0);
 
+            var brakeForwardOffset = Math.Max(0.01f, engineForwardOffset * 0.6f);
+
             var enginePos = PlaceOnArc(listenerX, listenerZ, angle, engineForwardOffset, engineForwardOffset);
             var brakePos = PlaceOnArc(listenerX, listenerZ, angle, 
                 _settings.StereoWidening ? engineForwardOffset : brakeForwardOffset, 

--- a/top_speed_net/TopSpeed/Vehicles/Spatial/Spatial.cs
+++ b/top_speed_net/TopSpeed/Vehicles/Spatial/Spatial.cs
@@ -73,17 +73,13 @@ namespace TopSpeed.Vehicles
             // Maps the sound to a 180-degree arc relative to the listener.
             var angle = normalized * (float)(Math.PI / 2.0);
 
-            // Conditional Radius Synchronization:
-            // When widening is ON, we use a consistent radius for horizontal movement to ensure terrain 
-            // sounds follow the car in unison. When OFF, we use the vanilla per-source radii.
-            var horizontalRadiusEngine = engineForwardOffset;
-            var horizontalRadiusBrake = _settings.StereoWidening ? engineForwardOffset : Math.Max(0.01f, engineForwardOffset * 0.6f);
-            var horizontalRadiusVehicle = _settings.StereoWidening ? engineForwardOffset : vehicleForwardOffset;
-
-            var enginePos = PlaceOnArc(listenerX, listenerZ, angle, horizontalRadiusEngine, engineForwardOffset);
-            var brakeForwardOffset = Math.Max(0.01f, engineForwardOffset * 0.6f);
-            var brakePos = PlaceOnArc(listenerX, listenerZ, angle, horizontalRadiusBrake, brakeForwardOffset);
-            var vehiclePos = PlaceOnArc(listenerX, listenerZ, angle, horizontalRadiusVehicle, vehicleForwardOffset);
+            var enginePos = PlaceOnArc(listenerX, listenerZ, angle, engineForwardOffset, engineForwardOffset);
+            var brakePos = PlaceOnArc(listenerX, listenerZ, angle, 
+                _settings.StereoWidening ? engineForwardOffset : brakeForwardOffset, 
+                brakeForwardOffset);
+            var vehiclePos = PlaceOnArc(listenerX, listenerZ, angle, 
+                _settings.StereoWidening ? engineForwardOffset : vehicleForwardOffset, 
+                vehicleForwardOffset);
             var crashPos = vehiclePos;
             if (_state == CarState.Crashing || _state == CarState.Crashed || _state == CarState.Starting)
             {
@@ -127,12 +123,16 @@ namespace TopSpeed.Vehicles
 
         private static Vector3 PlaceOnArc(float listenerX, float listenerZ, float angle, float horizontalRadius, float forwardOffset)
         {
-            var absHorizontalRadius = Math.Abs(horizontalRadius);
-            if (absHorizontalRadius < 0.01f)
-                absHorizontalRadius = 0.01f;
+            var hRadius = Math.Abs(horizontalRadius);
+            if (hRadius < 0.01f)
+                hRadius = 0.01f;
 
-            var offsetX = (float)Math.Sin(angle) * absHorizontalRadius;
-            var offsetZ = (float)Math.Cos(angle) * Math.Abs(forwardOffset);
+            var zRadius = Math.Abs(forwardOffset);
+            if (zRadius < 0.01f)
+                zRadius = 0.01f;
+
+            var offsetX = (float)Math.Sin(angle) * hRadius;
+            var offsetZ = (float)Math.Cos(angle) * zRadius;
             if (forwardOffset < 0f)
                 offsetZ = -offsetZ;
 

--- a/top_speed_net/TopSpeed/Vehicles/Spatial/Spatial.cs
+++ b/top_speed_net/TopSpeed/Vehicles/Spatial/Spatial.cs
@@ -70,6 +70,7 @@ namespace TopSpeed.Vehicles
             if (Math.Abs(vehicleForwardOffset) < 0.01f)
                 vehicleForwardOffset = vehicleForwardOffset >= 0f ? 0.01f : -0.01f;
 
+            // Maps the sound to a 180-degree arc relative to the listener.
             var angle = normalized * (float)(Math.PI / 2.0);
 
             var enginePos = PlaceOnArc(listenerX, listenerZ, angle, engineForwardOffset);

--- a/top_speed_net/TopSpeed/Vehicles/Spatial/Spatial.cs
+++ b/top_speed_net/TopSpeed/Vehicles/Spatial/Spatial.cs
@@ -73,10 +73,17 @@ namespace TopSpeed.Vehicles
             // Maps the sound to a 180-degree arc relative to the listener.
             var angle = normalized * (float)(Math.PI / 2.0);
 
-            var enginePos = PlaceOnArc(listenerX, listenerZ, angle, engineForwardOffset);
+            // Conditional Radius Synchronization:
+            // When widening is ON, we use a consistent radius for horizontal movement to ensure terrain 
+            // sounds follow the car in unison. When OFF, we use the vanilla per-source radii.
+            var horizontalRadiusEngine = engineForwardOffset;
+            var horizontalRadiusBrake = _settings.StereoWidening ? engineForwardOffset : Math.Max(0.01f, engineForwardOffset * 0.6f);
+            var horizontalRadiusVehicle = _settings.StereoWidening ? engineForwardOffset : vehicleForwardOffset;
+
+            var enginePos = PlaceOnArc(listenerX, listenerZ, angle, horizontalRadiusEngine, engineForwardOffset);
             var brakeForwardOffset = Math.Max(0.01f, engineForwardOffset * 0.6f);
-            var brakePos = PlaceOnArc(listenerX, listenerZ, angle, brakeForwardOffset);
-            var vehiclePos = PlaceOnArc(listenerX, listenerZ, angle, vehicleForwardOffset);
+            var brakePos = PlaceOnArc(listenerX, listenerZ, angle, horizontalRadiusBrake, brakeForwardOffset);
+            var vehiclePos = PlaceOnArc(listenerX, listenerZ, angle, horizontalRadiusVehicle, vehicleForwardOffset);
             var crashPos = vehiclePos;
             if (_state == CarState.Crashing || _state == CarState.Crashed || _state == CarState.Starting)
             {
@@ -118,14 +125,13 @@ namespace TopSpeed.Vehicles
             }
         }
 
-        private static Vector3 PlaceOnArc(float listenerX, float listenerZ, float angle, float forwardOffset)
+        private static Vector3 PlaceOnArc(float listenerX, float listenerZ, float angle, float horizontalRadius, float forwardOffset)
         {
-            var radius = Math.Abs(forwardOffset);
-            if (radius < 0.01f)
-                radius = 0.01f;
+            if (horizontalRadius < 0.01f)
+                horizontalRadius = 0.01f;
 
-            var offsetX = (float)Math.Sin(angle) * radius;
-            var offsetZ = (float)Math.Cos(angle) * radius;
+            var offsetX = (float)Math.Sin(angle) * horizontalRadius;
+            var offsetZ = (float)Math.Cos(angle) * Math.Abs(forwardOffset);
             if (forwardOffset < 0f)
                 offsetZ = -offsetZ;
 

--- a/top_speed_net/TopSpeed/Vehicles/Spatial/Spatial.cs
+++ b/top_speed_net/TopSpeed/Vehicles/Spatial/Spatial.cs
@@ -127,10 +127,11 @@ namespace TopSpeed.Vehicles
 
         private static Vector3 PlaceOnArc(float listenerX, float listenerZ, float angle, float horizontalRadius, float forwardOffset)
         {
-            if (horizontalRadius < 0.01f)
-                horizontalRadius = 0.01f;
+            var absHorizontalRadius = Math.Abs(horizontalRadius);
+            if (absHorizontalRadius < 0.01f)
+                absHorizontalRadius = 0.01f;
 
-            var offsetX = (float)Math.Sin(angle) * horizontalRadius;
+            var offsetX = (float)Math.Sin(angle) * absHorizontalRadius;
             var offsetZ = (float)Math.Cos(angle) * Math.Abs(forwardOffset);
             if (forwardOffset < 0f)
                 offsetZ = -offsetZ;


### PR DESCRIPTION
### Objective
This PR introduces an optional \"Stereo Widening\" feature for the player's vehicle. It is designed to improve directional awareness and help drivers more precisely perceive their position on the track. **This feature works regardless of whether HRTF mode is enabled or disabled.**

### Key Changes
- **New Setting**: Added `Enable stereo widening for own car` in **Options -> Game Settings**.
- **Universal Support**: The widening logic applies to all spatialized player car sounds in both **HRTF** and **Standard 3D** modes.
- **Surgical Separation**: When enabled, the spatializer applies automatic channel attenuation (Ear Kill). This quietens the opposite ear as the sound reaches the edges of the track (linear attenuation with a 10% buffer), providing much clearer directional separation.
- **Synchronized Tracking**: Synchronizes the horizontal panning radii of terrain and engine sounds **only when enabled**, ensuring the car feels like a unified object without affecting vanilla behavior when disabled.
- **Vanilla Parity**: Meticulously ensured that when the feature is **OFF**, the code path is bit-identical to the original logic, with no side effects or extra overhead.
- **Safety**: The logic is restricted strictly to the player's vehicle; environmental reverbs and other cars remain untouched and realistic.

### Note
Vibe coding was utilized to make the changes in this PR.