### PR TITLE
Implement Progressive (Pseudo-Analog) Keyboard Control

### DIFF
--- a/top_speed_net/TopSpeed.Shared/Protocol/Enums.cs
+++ b/top_speed_net/TopSpeed.Shared/Protocol/Enums.cs
@@ -140,4 +140,13 @@ namespace TopSpeed.Protocol
         ClientTooNew = 4,
         NoCommonVersion = 5
     }
+
+    public enum KeyboardProgressiveRate : byte
+    {
+        Off = 0,
+        Instant_0_25s = 1,
+        Instant_0_50s = 2,
+        Instant_0_75s = 3,
+        Instant_1_00s = 4
+    }
 }

--- a/top_speed_net/TopSpeed/Core/Settings/Contracts.cs
+++ b/top_speed_net/TopSpeed/Core/Settings/Contracts.cs
@@ -74,6 +74,9 @@ namespace TopSpeed.Core.Settings
         [DataMember(Name = "forceFeedback")]
         public bool? ForceFeedback { get; set; }
 
+        [DataMember(Name = "keyboardProgressiveRate")]
+        public int? KeyboardProgressiveRate { get; set; }
+
         [DataMember(Name = "deviceMode")]
         public int? DeviceMode { get; set; }
 

--- a/top_speed_net/TopSpeed/Core/Settings/SettingsManager.Apply.cs
+++ b/top_speed_net/TopSpeed/Core/Settings/SettingsManager.Apply.cs
@@ -126,6 +126,7 @@ namespace TopSpeed.Core.Settings
             if (input.ForceFeedback.HasValue)
                 settings.ForceFeedback = input.ForceFeedback.Value;
 
+            settings.KeyboardProgressiveRate = ReadEnum(input.KeyboardProgressiveRate, settings.KeyboardProgressiveRate, "input.keyboardProgressiveRate", issues);
             settings.DeviceMode = ReadEnum(input.DeviceMode, settings.DeviceMode, "input.deviceMode", issues);
 
             if (input.Keyboard == null)

--- a/top_speed_net/TopSpeed/Core/Settings/SettingsManager.Serialization.cs
+++ b/top_speed_net/TopSpeed/Core/Settings/SettingsManager.Serialization.cs
@@ -163,6 +163,7 @@ namespace TopSpeed.Core.Settings
                 Input = new SettingsInputDocument
                 {
                     ForceFeedback = settings.ForceFeedback,
+                    KeyboardProgressiveRate = (int)settings.KeyboardProgressiveRate,
                     DeviceMode = (int)settings.DeviceMode,
                     Keyboard = new SettingsKeyboardDocument
                     {

--- a/top_speed_net/TopSpeed/Core/Settings/SettingsManager.Validation.cs
+++ b/top_speed_net/TopSpeed/Core/Settings/SettingsManager.Validation.cs
@@ -100,16 +100,25 @@ namespace TopSpeed.Core.Settings
             return fallback;
         }
 
-        private static TEnum ReadEnum<TEnum>(int? value, TEnum fallback, string field, List<SettingsIssue> issues)
+        private static TEnum ReadEnum<TEnum>(object? value, TEnum fallback, string field, List<SettingsIssue> issues)
             where TEnum : struct, Enum
         {
-            if (!value.HasValue)
+            if (value == null)
                 return fallback;
 
-            if (Enum.IsDefined(typeof(TEnum), value.Value))
-                return (TEnum)Enum.ToObject(typeof(TEnum), value.Value);
+            try
+            {
+                var underlyingType = Enum.GetUnderlyingType(typeof(TEnum));
+                var converted = Convert.ChangeType(value, underlyingType);
+                if (Enum.IsDefined(typeof(TEnum), converted))
+                    return (TEnum)Enum.ToObject(typeof(TEnum), converted);
+            }
+            catch
+            {
+                // Fall through to error
+            }
 
-            issues.Add(new SettingsIssue(SettingsIssueSeverity.Warning, field, $"The key {field} has invalid value {value.Value}, which was replaced with {(int)(object)fallback}."));
+            issues.Add(new SettingsIssue(SettingsIssueSeverity.Warning, field, $"The key {field} has invalid value {value}, which was replaced with {fallback}."));
             return fallback;
         }
     }

--- a/top_speed_net/TopSpeed/Game/Game.cs
+++ b/top_speed_net/TopSpeed/Game/Game.cs
@@ -150,9 +150,9 @@ namespace TopSpeed.Game
         {
             _input.Update();
             if (_input.TryGetJoystickState(out var joystick))
-                _raceInput.Run(_input.Current, joystick);
+                _raceInput.Run(_input.Current, joystick, deltaSeconds);
             else
-                _raceInput.Run(_input.Current);
+                _raceInput.Run(_input.Current, deltaSeconds);
 
             _raceInput.SetOverlayInputBlocked(
                 _state == AppState.MultiplayerRace &&

--- a/top_speed_net/TopSpeed/Input/Race/Drive.cs
+++ b/top_speed_net/TopSpeed/Input/Race/Drive.cs
@@ -1,4 +1,6 @@
 using SharpDX.DirectInput;
+using TopSpeed.Protocol;
+using System;
 
 namespace TopSpeed.Input
 {
@@ -15,19 +17,17 @@ namespace TopSpeed.Input
                 var left = GetAxis(_left);
                 var right = GetAxis(_right);
                 joystickSteer = left != 0 ? -left : right;
-                if (joystickSteer != 0 || !UseKeyboard)
-                    return joystickSteer;
             }
 
-            if (UseKeyboard)
-            {
-                if (_lastState.IsDown(_kbLeft))
-                    return -100;
-                if (_lastState.IsDown(_kbRight))
-                    return 100;
-            }
+            if (!UseKeyboard)
+                return joystickSteer;
 
-            return joystickSteer;
+            var keyboardSteer = _settings.KeyboardProgressiveRate != KeyboardProgressiveRate.Off
+                ? (int)(_simSteer * 100.0f)
+                : (_lastState.IsDown(_kbLeft) ? -100 : (_lastState.IsDown(_kbRight) ? 100 : 0));
+
+            // Return the value with the greater magnitude (furthest from center)
+            return Math.Abs(keyboardSteer) > Math.Abs(joystickSteer) ? keyboardSteer : joystickSteer;
         }
 
         public int GetThrottle()
@@ -36,10 +36,14 @@ namespace TopSpeed.Input
                 return 0;
 
             var joystickThrottle = UseJoystick ? GetAxis(_throttle) : 0;
-            if (joystickThrottle != 0 || !UseKeyboard)
+            if (!UseKeyboard)
                 return joystickThrottle;
 
-            return UseKeyboard && _lastState.IsDown(_kbThrottle) ? 100 : 0;
+            var keyboardThrottle = _settings.KeyboardProgressiveRate != KeyboardProgressiveRate.Off
+                ? (int)(_simThrottle * 100.0f)
+                : (_lastState.IsDown(_kbThrottle) ? 100 : 0);
+
+            return Math.Max(joystickThrottle, keyboardThrottle);
         }
 
         public int GetBrake()
@@ -48,10 +52,15 @@ namespace TopSpeed.Input
                 return 0;
 
             var joystickBrake = UseJoystick ? -GetAxis(_brake) : 0;
-            if (joystickBrake != 0 || !UseKeyboard)
+            if (!UseKeyboard)
                 return joystickBrake;
 
-            return UseKeyboard && _lastState.IsDown(_kbBrake) ? -100 : 0;
+            var keyboardBrake = _settings.KeyboardProgressiveRate != KeyboardProgressiveRate.Off
+                ? (int)(_simBrake * -100.0f)
+                : (_lastState.IsDown(_kbBrake) ? -100 : 0);
+
+            // Return the more negative value (stronger braking)
+            return Math.Min(joystickBrake, keyboardBrake);
         }
 
         public bool GetReverseRequested() => _allowDrivingInput && UseKeyboard && WasPressed(Key.Z);

--- a/top_speed_net/TopSpeed/Input/Race/RaceInput.cs
+++ b/top_speed_net/TopSpeed/Input/Race/RaceInput.cs
@@ -129,6 +129,11 @@ namespace TopSpeed.Input
         private bool _allowDrivingInput;
         private bool _allowAuxiliaryInput;
         private bool _overlayInputBlocked;
+
+        private float _simThrottle;
+        private float _simBrake;
+        private float _simSteer;
+
         private bool UseJoystick => _deviceMode != InputDeviceMode.Keyboard && _joystickAvailable;
         private bool UseKeyboard => _deviceMode != InputDeviceMode.Joystick || !_joystickAvailable;
 

--- a/top_speed_net/TopSpeed/Input/Race/State.cs
+++ b/top_speed_net/TopSpeed/Input/Race/State.cs
@@ -1,4 +1,6 @@
 using SharpDX.DirectInput;
+using TopSpeed.Protocol;
+using System;
 
 namespace TopSpeed.Input
 {
@@ -49,12 +51,12 @@ namespace TopSpeed.Input
             _kbFlush = Key.LeftAlt;
         }
 
-        public void Run(InputState input)
+        public void Run(InputState input, float deltaSeconds)
         {
-            Run(input, null);
+            Run(input, null, deltaSeconds);
         }
 
-        public void Run(InputState input, JoystickStateSnapshot? joystick)
+        public void Run(InputState input, JoystickStateSnapshot? joystick, float deltaSeconds)
         {
             _prevState.CopyFrom(_lastState);
             _lastState.CopyFrom(input);
@@ -75,6 +77,69 @@ namespace TopSpeed.Input
             _joystickAvailable = joystick.HasValue;
             if (!joystick.HasValue)
                 _hasPrevJoystick = false;
+
+            UpdateSimulatedInputs(deltaSeconds);
+        }
+
+        private void UpdateSimulatedInputs(float deltaSeconds)
+        {
+            if (_settings.KeyboardProgressiveRate == KeyboardProgressiveRate.Off)
+            {
+                _simThrottle = _lastState.IsDown(_kbThrottle) ? 1.0f : 0.0f;
+                _simBrake = _lastState.IsDown(_kbBrake) ? 1.0f : 0.0f;
+                if (_lastState.IsDown(_kbLeft)) _simSteer = -1.0f;
+                else if (_lastState.IsDown(_kbRight)) _simSteer = 1.0f;
+                else _simSteer = 0.0f;
+                return;
+            }
+
+            float rate = _settings.KeyboardProgressiveRate switch
+            {
+                KeyboardProgressiveRate.Instant_0_25s => 0.25f,
+                KeyboardProgressiveRate.Instant_0_50s => 0.50f,
+                KeyboardProgressiveRate.Instant_0_75s => 0.75f,
+                KeyboardProgressiveRate.Instant_1_00s => 1.00f,
+                _ => 0.50f
+            };
+
+            // Throttle
+            if (_lastState.IsDown(_kbThrottle))
+            {
+                _simBrake = 0f; // Opposite kill
+                _simThrottle = Math.Min(1.0f, _simThrottle + (deltaSeconds / rate));
+            }
+            else
+            {
+                _simThrottle = Math.Max(0f, _simThrottle - (deltaSeconds / rate));
+            }
+
+            // Brake
+            if (_lastState.IsDown(_kbBrake))
+            {
+                _simThrottle = 0f; // Opposite kill
+                _simBrake = Math.Min(1.0f, _simBrake + (deltaSeconds / rate));
+            }
+            else
+            {
+                _simBrake = Math.Max(0f, _simBrake - (deltaSeconds / rate));
+            }
+
+            // Steering
+            if (_lastState.IsDown(_kbLeft))
+            {
+                if (_simSteer > 0f) _simSteer = 0f; // Opposite kill
+                _simSteer = Math.Max(-1.0f, _simSteer - (deltaSeconds / rate));
+            }
+            else if (_lastState.IsDown(_kbRight))
+            {
+                if (_simSteer < 0f) _simSteer = 0f; // Opposite kill
+                _simSteer = Math.Min(1.0f, _simSteer + (deltaSeconds / rate));
+            }
+            else
+            {
+                if (_simSteer > 0) _simSteer = Math.Max(0f, _simSteer - (deltaSeconds / rate));
+                else if (_simSteer < 0) _simSteer = Math.Min(0f, _simSteer + (deltaSeconds / rate));
+            }
         }
 
         public void SetCenter(JoystickStateSnapshot center)

--- a/top_speed_net/TopSpeed/Input/Settings/RaceSettings.cs
+++ b/top_speed_net/TopSpeed/Input/Settings/RaceSettings.cs
@@ -1,4 +1,5 @@
 using SharpDX.DirectInput;
+using TopSpeed.Protocol;
 using System;
 using System.Collections.Generic;
 
@@ -52,6 +53,7 @@ namespace TopSpeed.Input
         public Key KeyPause { get; set; }
 
         public bool ForceFeedback { get; set; }
+        public KeyboardProgressiveRate KeyboardProgressiveRate { get; set; }
         public InputDeviceMode DeviceMode { get; set; }
 
         public AutomaticInfoMode AutomaticInfo { get; set; }
@@ -126,6 +128,7 @@ namespace TopSpeed.Input
             KeyPause = Key.P;
 
             ForceFeedback = false;
+            KeyboardProgressiveRate = KeyboardProgressiveRate.Off;
             DeviceMode = InputDeviceMode.Keyboard;
             AutomaticInfo = AutomaticInfoMode.On;
             Copilot = CopilotMode.All;

--- a/top_speed_net/TopSpeed/Menu/registry/options/Controls.cs
+++ b/top_speed_net/TopSpeed/Menu/registry/options/Controls.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using TopSpeed.Input;
+using TopSpeed.Protocol;
 
 namespace TopSpeed.Menu
 {
@@ -15,6 +16,12 @@ namespace TopSpeed.Menu
                     () => _settings.ForceFeedback,
                     value => _settingsActions.UpdateSetting(() => _settings.ForceFeedback = value),
                     hint: "Enables force feedback or vibration if your controller supports it. Press ENTER to toggle."),
+                new RadioButton(
+                    "Progressive (Pseudo-Analog) keyboard input",
+                    new[] { "off", "0.25s", "0.50s", "0.75s", "1.00s" },
+                    () => (int)_settings.KeyboardProgressiveRate,
+                    value => _settingsActions.UpdateSetting(() => _settings.KeyboardProgressiveRate = (KeyboardProgressiveRate)value),
+                    hint: "When off, car controls immediately jump to 100 percent as soon as keys are pressed. The further right this is, the slower the car's control chases the state of your keyboard, allowing to feather throttle, brakes, etc. The opposite key can be used for immediate reset, so steer left will disable a progressively releasing steer right for example."),
                 new MenuItem("Map keyboard keys", MenuAction.None, nextMenuId: "options_controls_keyboard"),
                 new MenuItem("Map joystick keys", MenuAction.None, nextMenuId: "options_controls_joystick"),
                 BackItem()


### PR DESCRIPTION
### Objective
This PR introduces a \"Pseudo-Analog\" input system for keyboard players. It allows throttle, brake, and steering to ramp up/down over time, simulating the physical depth of a joystick or pedal. This provides keyboard players with the ability to \"feather\" their inputs for much more precise car control.

### Key Features
- **New Control Setting**: Added \"Progressive (Pseudo-Analog) keyboard input\" in **Options -> Controls**.
- **Adjustable Rates**: Users can select ramp speeds from **Off** (instant) up to **1.00s**. 
- **Opposite Key Kill**: Implemented logic where pressing an opposite key (e.g., Brake while accelerating) instantly resets the current value to zero. This allows for immediate tactical \"resets\" during high-speed driving.
- **Improved \"Both\" Mode**: Updated the input priority logic. If both a joystick and keyboard are used, the game now prioritizes the input with the higher magnitude, ensuring a seamless transition between the two.
- **Frame-Rate Independence**: The ramping logic utilizes delta time to ensure consistent behavior regardless of computer speed.

### Engine Hardening
- **Robust Settings Loading**: Enhanced the generic `ReadEnum` method in `SettingsManager` to safely handle type conversions (e.g., JSON Int32 to Enum Byte). This prevents crashes when introducing new settings with optimized underlying types.

### Note
Vibe coding was utilized to make the changes in this PR.