### PR TITLE
Fix Linux menu input and language asset lookup

### DIFF
--- a/top_speed_net/TopSpeed.Shared/Runtime/RuntimeAssetPathResolver.cs
+++ b/top_speed_net/TopSpeed.Shared/Runtime/RuntimeAssetPathResolver.cs
@@ -1,0 +1,59 @@
+using System;
+using System.IO;
+
+namespace TopSpeed.Runtime
+{
+    public static class RuntimeAssetPathResolver
+    {
+        public static string? ResolveExistingPath(string rootPath, params string[] segments)
+        {
+            if (string.IsNullOrWhiteSpace(rootPath) || segments == null || segments.Length == 0)
+                return null;
+            if (!Directory.Exists(rootPath))
+                return null;
+
+            var currentPath = rootPath;
+            for (var i = 0; i < segments.Length; i++)
+            {
+                var segment = segments[i];
+                if (string.IsNullOrWhiteSpace(segment))
+                    return null;
+
+                var normalized = segment
+                    .Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar)
+                    .Replace(Path.DirectorySeparatorChar == '\\' ? '/' : '\\', Path.DirectorySeparatorChar);
+                var parts = normalized.Split(new[] { Path.DirectorySeparatorChar }, StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length == 0)
+                    return null;
+
+                for (var j = 0; j < parts.Length; j++)
+                {
+                    var resolvedPath = ResolveExistingChild(currentPath, parts[j]);
+                    if (resolvedPath == null)
+                        return null;
+                    currentPath = resolvedPath;
+                }
+            }
+
+            return currentPath;
+        }
+
+        private static string? ResolveExistingChild(string parentPath, string childName)
+        {
+            if (!Directory.Exists(parentPath))
+                return null;
+
+            var exactPath = Path.Combine(parentPath, childName);
+            if (Directory.Exists(exactPath) || File.Exists(exactPath))
+                return exactPath;
+
+            foreach (var entryPath in Directory.EnumerateFileSystemEntries(parentPath))
+            {
+                if (string.Equals(Path.GetFileName(entryPath), childName, StringComparison.OrdinalIgnoreCase))
+                    return entryPath;
+            }
+
+            return null;
+        }
+    }
+}

--- a/top_speed_net/TopSpeed.Tests/Behavior/Shared/Runtime/RuntimeAssetPathResolverBehavior.cs
+++ b/top_speed_net/TopSpeed.Tests/Behavior/Shared/Runtime/RuntimeAssetPathResolverBehavior.cs
@@ -1,0 +1,46 @@
+using System;
+using System.IO;
+using TopSpeed.Runtime;
+using Xunit;
+
+namespace TopSpeed.Tests
+{
+    [Trait("Category", "Behavior")]
+    public sealed class RuntimeAssetPathResolverBehaviorTests
+    {
+        [Fact]
+        public void ResolveExistingPath_ShouldMatchSegmentsCaseInsensitively()
+        {
+            using var fixture = new AssetFixture();
+
+            var resolved = RuntimeAssetPathResolver.ResolveExistingPath(
+                fixture.RootPath,
+                "Sounds",
+                "en",
+                "music\\theme4.ogg");
+
+            resolved.Should().Be(fixture.SoundPath);
+        }
+
+        private sealed class AssetFixture : IDisposable
+        {
+            public AssetFixture()
+            {
+                RootPath = Path.Combine(Path.GetTempPath(), "topspeed-asset-paths-" + Guid.NewGuid().ToString("N"));
+                Directory.CreateDirectory(Path.Combine(RootPath, "Sounds", "En", "Music"));
+                SoundPath = Path.Combine(RootPath, "Sounds", "En", "Music", "theme4.ogg");
+                File.WriteAllBytes(SoundPath, Array.Empty<byte>());
+            }
+
+            public string RootPath { get; }
+
+            public string SoundPath { get; }
+
+            public void Dispose()
+            {
+                if (Directory.Exists(RootPath))
+                    Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/top_speed_net/TopSpeed/Core/AssetPaths.cs
+++ b/top_speed_net/TopSpeed/Core/AssetPaths.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using TopSpeed.Runtime;
 
 namespace TopSpeed.Core
 {
@@ -21,6 +22,10 @@ namespace TopSpeed.Core
         }
 
         public static string SoundsRoot => Path.Combine(Root, "Sounds");
+
+        public static string? ResolveExistingPath(params string[] segments)
+        {
+            return RuntimeAssetPathResolver.ResolveExistingPath(Root, segments);
+        }
     }
 }
-

--- a/top_speed_net/TopSpeed/Drive/Multiplayer/Session/Setup/Assets.cs
+++ b/top_speed_net/TopSpeed/Drive/Multiplayer/Session/Setup/Assets.cs
@@ -125,14 +125,12 @@ namespace TopSpeed.Drive.Multiplayer
             var relative = key.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
             if (string.IsNullOrWhiteSpace(Path.GetExtension(relative)))
                 relative += ".ogg";
-            var path = Path.Combine(AssetPaths.SoundsRoot, language, relative);
-            return File.Exists(path) ? path : null;
+            return AssetPaths.ResolveExistingPath("Sounds", language, relative);
         }
 
         private static string? GetLegacySoundPath(string fileName)
         {
-            var path = Path.Combine(AssetPaths.SoundsRoot, "Legacy", fileName);
-            return File.Exists(path) ? path : null;
+            return AssetPaths.ResolveExistingPath("Sounds", "Legacy", fileName);
         }
 
         private Source LoadBusSource(string path, string busName, bool streamFromDisk)

--- a/top_speed_net/TopSpeed/Drive/Single/Session/Assets.cs
+++ b/top_speed_net/TopSpeed/Drive/Single/Session/Assets.cs
@@ -174,14 +174,12 @@ namespace TopSpeed.Drive.Single
             var relative = key.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
             if (string.IsNullOrWhiteSpace(Path.GetExtension(relative)))
                 relative += ".ogg";
-            var path = Path.Combine(AssetPaths.SoundsRoot, language, relative);
-            return File.Exists(path) ? path : null;
+            return AssetPaths.ResolveExistingPath("Sounds", language, relative);
         }
 
         private static string? GetLegacySoundPath(string fileName)
         {
-            var path = Path.Combine(AssetPaths.SoundsRoot, "Legacy", fileName);
-            return File.Exists(path) ? path : null;
+            return AssetPaths.ResolveExistingPath("Sounds", "Legacy", fileName);
         }
 
         private Source LoadBusSource(string path, string busName, bool streamFromDisk)

--- a/top_speed_net/TopSpeed/Drive/TimeTrial/Session/Assets.cs
+++ b/top_speed_net/TopSpeed/Drive/TimeTrial/Session/Assets.cs
@@ -117,14 +117,12 @@ namespace TopSpeed.Drive.TimeTrial
             var relative = key.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
             if (string.IsNullOrWhiteSpace(Path.GetExtension(relative)))
                 relative += ".ogg";
-            var path = Path.Combine(AssetPaths.SoundsRoot, language, relative);
-            return File.Exists(path) ? path : null;
+            return AssetPaths.ResolveExistingPath("Sounds", language, relative);
         }
 
         private static string? GetLegacySoundPath(string fileName)
         {
-            var path = Path.Combine(AssetPaths.SoundsRoot, "Legacy", fileName);
-            return File.Exists(path) ? path : null;
+            return AssetPaths.ResolveExistingPath("Sounds", "Legacy", fileName);
         }
 
         private Source LoadBusSource(string path, string busName, bool streamFromDisk)

--- a/top_speed_net/TopSpeed/Game/Menu/About.cs
+++ b/top_speed_net/TopSpeed/Game/Menu/About.cs
@@ -7,7 +7,8 @@ using TopSpeed.Protocol;
 #if NETFRAMEWORK
 using System.Windows.Forms;
 #else
-using Eto.Forms;
+using EtoApplication = Eto.Forms.Application;
+using EtoClipboard = Eto.Forms.Clipboard;
 #endif
 
 namespace TopSpeed.Game
@@ -86,7 +87,7 @@ namespace TopSpeed.Game
 #else
             try
             {
-                var app = Application.Instance;
+                var app = EtoApplication.Instance;
                 if (app == null)
                     return false;
 
@@ -95,7 +96,7 @@ namespace TopSpeed.Game
                 {
                     try
                     {
-                        Clipboard.Instance.Text = text;
+                        EtoClipboard.Instance.Text = text;
                         copied = true;
                     }
                     catch

--- a/top_speed_net/TopSpeed/TopSpeed.csproj
+++ b/top_speed_net/TopSpeed/TopSpeed.csproj
@@ -215,7 +215,7 @@
     <Exec Command="python &quot;$(MSBuildThisFileDirectory)..\..\docs\render_docs.py&quot;" ContinueOnError="WarnAndContinue" />
   </Target>
 
-  <Target Name="CopyUpdater" AfterTargets="Build" Condition="'$(TargetFramework)' == 'net472'">
+  <Target Name="CopyUpdater" AfterTargets="Build" Condition="'$(SkipClientUpdaterBuild)' != 'true' and '$(TargetFramework)' == 'net472'">
     <PropertyGroup>
       <_UpdaterProjectPath>$(MSBuildThisFileDirectory)../Updater/Updater.csproj</_UpdaterProjectPath>
       <_UpdaterBuildDir>$(MSBuildThisFileDirectory)../Updater/bin/$(Configuration)/net472/</_UpdaterBuildDir>
@@ -226,7 +226,7 @@
     <Copy SourceFiles="$(_UpdaterBuildDir)Updater.pdb" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" Condition="Exists('$(_UpdaterBuildDir)Updater.pdb')" />
   </Target>
 
-  <Target Name="CopyUpdaterNet10" AfterTargets="Build" Condition="('$(TargetFramework)' == 'net10.0' or '$(TargetFramework)' == 'net10.0-windows') and '$(RuntimeIdentifier)' != ''">
+  <Target Name="CopyUpdaterNet10" AfterTargets="Build" Condition="'$(SkipClientUpdaterBuild)' != 'true' and ('$(TargetFramework)' == 'net10.0' or '$(TargetFramework)' == 'net10.0-windows') and '$(RuntimeIdentifier)' != ''">
     <PropertyGroup>
       <_UpdaterProjectPath>$(MSBuildThisFileDirectory)../Updater/Updater.csproj</_UpdaterProjectPath>
       <_UpdaterOutputPath>$([System.IO.Path]::GetFullPath('$(OutDir)'))</_UpdaterOutputPath>
@@ -240,7 +240,7 @@
     <Copy SourceFiles="@(_UpdaterPublishedFiles)" DestinationFiles="@(_UpdaterPublishedFiles->'$(_UpdaterOutputPath)%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" />
   </Target>
 
-  <Target Name="PublishUpdaterNet10" AfterTargets="Publish" Condition="('$(TargetFramework)' == 'net10.0' or '$(TargetFramework)' == 'net10.0-windows') and '$(RuntimeIdentifier)' != ''">
+  <Target Name="PublishUpdaterNet10" AfterTargets="Publish" Condition="'$(SkipClientUpdaterBuild)' != 'true' and ('$(TargetFramework)' == 'net10.0' or '$(TargetFramework)' == 'net10.0-windows') and '$(RuntimeIdentifier)' != ''">
     <PropertyGroup>
       <_UpdaterProjectPath>$(MSBuildThisFileDirectory)../Updater/Updater.csproj</_UpdaterProjectPath>
       <_PublishDestinationPath>$([System.IO.Path]::GetFullPath('$(PublishDir)'))</_PublishDestinationPath>

--- a/top_speed_net/TopSpeed/Window/Eto/WindowHost.cs
+++ b/top_speed_net/TopSpeed/Window/Eto/WindowHost.cs
@@ -12,7 +12,7 @@ namespace TopSpeed.Windowing.Eto
         private readonly object _textInputLock = new object();
         private readonly Application _application;
         private readonly Form _window;
-        private readonly Panel _root;
+        private readonly Drawable _root;
         private TextBox? _inputBox;
         private bool _loadedRaised;
         private bool _submitPending;
@@ -45,7 +45,12 @@ namespace TopSpeed.Windowing.Eto
             _window.KeyDown += OnWindowKeyDown;
             _window.KeyUp += OnWindowKeyUp;
             _window.LostFocus += OnWindowLostFocus;
-            _root = new Panel();
+            _root = new Drawable
+            {
+                CanFocus = true
+            };
+            _root.KeyDown += OnWindowKeyDown;
+            _root.KeyUp += OnWindowKeyUp;
             _window.Content = _root;
         }
 
@@ -75,6 +80,8 @@ namespace TopSpeed.Windowing.Eto
             _window.KeyDown -= OnWindowKeyDown;
             _window.KeyUp -= OnWindowKeyUp;
             _window.LostFocus -= OnWindowLostFocus;
+            _root.KeyDown -= OnWindowKeyDown;
+            _root.KeyUp -= OnWindowKeyUp;
             DisposeInputBoxControl();
             _window.Dispose();
         }
@@ -109,7 +116,7 @@ namespace TopSpeed.Windowing.Eto
             InvokeOnUi(() =>
             {
                 HideInputBox();
-                _window.Focus();
+                _root.Focus();
             });
         }
 
@@ -142,7 +149,7 @@ namespace TopSpeed.Windowing.Eto
             {
                 _loadedRaised = true;
                 NativeHandle = ResolveNativeHandle(_window);
-                _window.Focus();
+                _root.Focus();
                 Loaded?.Invoke();
             }
         }


### PR DESCRIPTION
## Summary
- route Eto window input through a focusable root control so Enter and arrow keys reach Linux menus
- resolve language and legacy sound asset paths case-insensitively at runtime for Linux filesystems
- add a regression test for case-insensitive runtime asset resolution
- allow skipping updater packaging during client publish so Linux client builds can be tested directly

## Verification
- dotnet test top_speed_net/TopSpeed.Tests/TopSpeed.Tests.csproj -f net10.0 --filter "FullyQualifiedName~RuntimeAssetPathResolverBehaviorTests" -m:1 --disable-build-servers
- dotnet publish top_speed_net/TopSpeed/TopSpeed.csproj -c Release -f net10.0 -r linux-x64 -m:1 --disable-build-servers -p:SkipClientUpdaterBuild=true

## User-visible effect
- Linux menus now accept the expected activation/navigation keys
- Linux builds no longer crash on case-sensitive language sound paths such as music/theme4