### PR TITLE
Avoid startup crash from unsafe ZDSR backend

### DIFF
--- a/top_speed_net/TopSpeed/Program.cs
+++ b/top_speed_net/TopSpeed/Program.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -12,6 +13,7 @@ using Eto.Forms;
 using TopSpeed.Game;
 using TopSpeed.Localization;
 using TopSpeed.Runtime;
+using TopSpeed.Speech.Prism;
 #if WINDOWS
 using TopSpeed.Windowing.WinForms;
 #else
@@ -25,19 +27,26 @@ namespace TopSpeed
         private static int _exceptionHandled;
 
         [STAThread]
-        private static void Main()
+        private static void Main(string[] args)
         {
             RegisterGlobalExceptionHandlers();
 
             try
             {
+                TrySetCurrentDirectoryToBaseDirectory();
+                NativeLibraryBootstrap.Initialize();
+
+                if (TryRunPrismBackendProbe(args, out var probeExitCode))
+                {
+                    Environment.ExitCode = probeExitCode;
+                    return;
+                }
+
 #if WINDOWS
                 using var timerResolution = new WindowsTimerResolution(1);
                 Application.EnableVisualStyles();
                 Application.SetCompatibleTextRenderingDefault(false);
 #endif
-
-                NativeLibraryBootstrap.Initialize();
 
 #if WINDOWS
                 var window = new WindowHost();
@@ -64,6 +73,46 @@ namespace TopSpeed
             catch (Exception ex)
             {
                 HandleException(ex);
+            }
+        }
+
+        private static bool TryRunPrismBackendProbe(string[] args, out int exitCode)
+        {
+            exitCode = 0;
+            if (args.Length != 2 || !string.Equals(args[0], StartupArguments.PrismBackendProbe, StringComparison.Ordinal))
+                return false;
+
+            if (!ulong.TryParse(args[1], NumberStyles.HexNumber, null, out var backendId))
+            {
+                exitCode = 2;
+                return true;
+            }
+
+            try
+            {
+                using var context = new Context();
+                using var backend = context.Create(backendId);
+                exitCode = backend.IsSupportedAtRuntime ? 0 : 3;
+            }
+            catch
+            {
+                exitCode = 1;
+            }
+
+            return true;
+        }
+
+        private static void TrySetCurrentDirectoryToBaseDirectory()
+        {
+            try
+            {
+                var baseDirectory = AppContext.BaseDirectory;
+                if (!string.IsNullOrWhiteSpace(baseDirectory) && Directory.Exists(baseDirectory))
+                    Directory.SetCurrentDirectory(baseDirectory);
+            }
+            catch
+            {
+                // Startup can still continue; absolute base-directory probing remains available.
             }
         }
 

--- a/top_speed_net/TopSpeed/Runtime/StartupArguments.cs
+++ b/top_speed_net/TopSpeed/Runtime/StartupArguments.cs
@@ -1,0 +1,7 @@
+namespace TopSpeed.Runtime
+{
+    internal static class StartupArguments
+    {
+        public const string PrismBackendProbe = "--topspeed-prism-backend-probe";
+    }
+}

--- a/top_speed_net/TopSpeed/Speech/ScreenReaders/Prism/Reader.cs
+++ b/top_speed_net/TopSpeed/Speech/ScreenReaders/Prism/Reader.cs
@@ -1,6 +1,10 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
+using TopSpeed.Runtime;
 using TopSpeed.Speech.Playback;
 using TopSpeed.Speech.Prism;
 
@@ -18,6 +22,7 @@ namespace TopSpeed.Speech.ScreenReaders.Prism
         private bool _trySapi;
         private bool _preferSapi;
         private IPlayer? _player;
+        private static readonly ConcurrentDictionary<ulong, bool> BackendStartupProbeResults = new ConcurrentDictionary<ulong, bool>();
 
         public IReadOnlyList<SpeechBackendInfo> AvailableBackends
         {
@@ -33,6 +38,9 @@ namespace TopSpeed.Speech.ScreenReaders.Prism
                     for (var i = 0; i < source.Count; i++)
                     {
                         var info = source[i];
+                        if (!CanInitializeBackendInProcess(info.Id))
+                            continue;
+
                         if (!TryProbeSupportedBackend(_context, info, out var backendName))
                             continue;
 
@@ -389,7 +397,9 @@ namespace TopSpeed.Speech.ScreenReaders.Prism
         {
             if (_preferredBackendId.HasValue)
             {
-                var preferred = TryOpen(context, new BackendInfo(_preferredBackendId.Value, string.Empty, 0, true));
+                var preferred = !CanInitializeBackendInProcess(_preferredBackendId.Value)
+                    ? null
+                    : TryOpen(context, new BackendInfo(_preferredBackendId.Value, string.Empty, 0, true));
                 if (preferred != null)
                 {
                     _activeBackendId = ResolveActiveBackendId(context, preferred, _preferredBackendId.Value);
@@ -399,7 +409,7 @@ namespace TopSpeed.Speech.ScreenReaders.Prism
             }
 
             var candidates = context.AvailableBackends
-                .Where(static backend => backend.IsSupported)
+                .Where(static backend => backend.IsSupported && CanInitializeBackendInProcess(backend.Id))
                 .OrderByDescending(static backend => backend.Priority)
                 .ToArray();
 
@@ -439,10 +449,64 @@ namespace TopSpeed.Speech.ScreenReaders.Prism
                 }
             }
 
-            var best = context.AcquireBest();
-            _activeBackendId = ResolveActiveBackendId(context, best, null);
-            ApplyVoicePreferenceLocked();
-            return best;
+            throw new InvalidOperationException("No speech backend is available.");
+        }
+
+        private static bool CanInitializeBackendInProcess(ulong backendId)
+        {
+            if (!RequiresStartupProbe(backendId))
+                return true;
+
+            return BackendStartupProbeResults.GetOrAdd(backendId, ProbeBackendStartup);
+        }
+
+        private static bool RequiresStartupProbe(ulong backendId)
+        {
+            return backendId == Ids.Zdsr;
+        }
+
+        private static bool ProbeBackendStartup(ulong backendId)
+        {
+            var processPath = Environment.ProcessPath;
+            if (string.IsNullOrWhiteSpace(processPath))
+                return false;
+
+            try
+            {
+                var startInfo = new ProcessStartInfo
+                {
+                    FileName = processPath,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    WorkingDirectory = AppContext.BaseDirectory
+                };
+                startInfo.ArgumentList.Add(StartupArguments.PrismBackendProbe);
+                startInfo.ArgumentList.Add(backendId.ToString("X16", CultureInfo.InvariantCulture));
+
+                using var process = Process.Start(startInfo);
+
+                if (process == null)
+                    return false;
+
+                if (!process.WaitForExit(5000))
+                {
+                    try
+                    {
+                        process.Kill(entireProcessTree: true);
+                    }
+                    catch
+                    {
+                    }
+
+                    return false;
+                }
+
+                return process.ExitCode == 0;
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         private static Backend? TryOpen(Context context, BackendInfo info)


### PR DESCRIPTION
## Summary

This PR prevents Top Speed from exiting during startup when the installed Zhengdu/ZDSR screen reader backend crashes inside its native API.

The crash is not a normal managed exception. On affected machines, calling the ZDSR backend through Prism loads `ZDSRAPI_x64.dll`, and the process terminates with a native fast-fail / BEX64 crash (`0xc0000409`). Because this happens inside the native DLL, the existing `try/catch` around speech initialization cannot catch it, so the whole game process disappears during startup.

## Root cause found during investigation

On the affected Windows machine:

- TopSpeed `2026.5.4.2` crashed during startup with Windows Error Reporting showing `BEX64` and exception code `0xc0000409`.
- The process loaded Prism and then attempted to use the Zhengdu/ZDSR backend.
- A minimal Prism probe reproduced the crash specifically at ZDSR backend initialization.
- Direct calls into `ZDSRAPI_x64.dll` from a .NET 10 process also reproduced the same native process termination, even without the rest of Top Speed.
- The same ZDSR API calls from a .NET Framework 4.x x64 process returned normally, which suggests this is an incompatibility or fatal failure in the ZDSR native API when loaded into the modern .NET process, not a normal C# exception path.
- Comparing April and May revisions showed that the current May build uses the Prism DLL introduced in April; testing the April Prism DLL versions also reproduced the ZDSR crash. So this is not caused by a May-only DLL replacement. The failure is exposed by the Prism/ZDSR backend being selected on machines where ZDSR is installed.

## Fix

Instead of directly initializing known risky native speech backends inside the main game process, Top Speed now probes the ZDSR backend in a short-lived child process first.

- If the ZDSR probe exits successfully, ZDSR remains available.
- If the ZDSR probe crashes, hangs, or exits with an error, the main process treats that backend as unsafe and skips it.
- Other speech backends such as SAPI, OneCore, BoyPCReader, etc. can still be selected normally.
- The unsafe `AcquireBest()` fallback was removed from this path because it can choose the crashing ZDSR backend after the filtered candidate list has already rejected it.

This makes speech backend failure non-fatal for startup. A broken ZDSR installation or incompatible `ZDSRAPI_x64.dll` can no longer take down the main Top Speed process before the window appears.

## Verification

Tested on Windows with .NET SDK 10.0.203:

- `dotnet build top_speed_net/TopSpeed/TopSpeed.csproj --configuration Release`
  - Build succeeded with 0 warnings and 0 errors.
- Ran the ZDSR probe:
  - `TopSpeed.exe --topspeed-prism-backend-probe 3D93C56C9E7F2A2E`
  - The child process reproduced the native `0xc0000409` crash on the affected machine.
- Ran the SAPI probe:
  - `TopSpeed.exe --topspeed-prism-backend-probe 1D6DF72422CEEE66`
  - Exited successfully.
- Started the game normally:
  - Main window appeared with title `Top Speed`.
  - Process stayed responsive.
  - Main process did not load `ZDSRAPI_x64.dll`.
  - Prism/SAPI/OneCore and other non-crashing speech paths remained available.