### PR TITLE
Fix multiplayer room and track localization

### DIFF
--- a/top_speed_net/TopSpeed.Tests/Behavior/Shared/Localization/LocalizationBehavior.cs
+++ b/top_speed_net/TopSpeed.Tests/Behavior/Shared/Localization/LocalizationBehavior.cs
@@ -1,5 +1,9 @@
 using System;
 using System.Collections.Generic;
+using TopSpeed.Core;
+using TopSpeed.Core.Multiplayer;
+using TopSpeed.Core.Multiplayer.Chat;
+using TopSpeed.Data;
 using TopSpeed.Localization;
 using TopSpeed.Protocol;
 using TopSpeed.Vehicles;
@@ -56,6 +60,52 @@ namespace TopSpeed.Tests
             LocalizationService.Translate(OfficialVehicleCatalog.Vehicles[0].Name)
                 .Should()
                 .Be("日产 GT-R Nismo");
+        }
+
+        [Fact]
+        public void OnlinePlayers_MainRoom_ShouldTranslate()
+        {
+            using var scope = LocalizationScope.Map(new Dictionary<string, string>
+            {
+                ["main room"] = "主房间"
+            });
+
+            var result = OnlineMap.ToList(new PacketOnlinePlayers
+            {
+                Players = new[]
+                {
+                    new PacketOnlinePlayer
+                    {
+                        PlayerId = 1,
+                        PlayerNumber = 0,
+                        Name = "Shuyue",
+                        PresenceState = OnlinePresenceState.Available,
+                        RoomName = "main room"
+                    }
+                }
+            });
+
+            result.Players.Should().HaveCount(1);
+            result.Players[0].RoomName.Should().Be("主房间");
+        }
+
+        [Fact]
+        public void TrackChangedHistory_ShouldTranslateBuiltInTrackName()
+        {
+            using var scope = LocalizationScope.Map(new Dictionary<string, string>
+            {
+                ["Track changed to {0}."] = "赛道已更改为 {0}。",
+                [TrackList.RaceTracks[0].Display] = "美国"
+            });
+
+            var text = HistoryText.FromRoomEvent(new RoomEventInfo
+            {
+                Kind = RoomEventKind.TrackChanged,
+                Track = TrackPackageRef.BuiltIn(TrackList.RaceTracks[0].Key),
+                TrackName = TrackList.RaceTracks[0].Key
+            });
+
+            text.Should().Be("赛道已更改为 美国。");
         }
 
         private sealed class LocalizationScope : IDisposable

--- a/top_speed_net/TopSpeed/Core/Multiplayer/Chat/HistoryText.cs
+++ b/top_speed_net/TopSpeed/Core/Multiplayer/Chat/HistoryText.cs
@@ -70,7 +70,7 @@ namespace TopSpeed.Core.Multiplayer.Chat
                 case RoomEventKind.TrackChanged:
                     return LocalizationService.Format(
                         LocalizationService.Mark("Track changed to {0}."),
-                        roomEvent.TrackName);
+                        ResolveTrackName(roomEvent.Track, roomEvent.TrackName));
 
                 case RoomEventKind.LapsChanged:
                     return LocalizationService.Format(
@@ -139,6 +139,14 @@ namespace TopSpeed.Core.Multiplayer.Chat
             if (!string.IsNullOrWhiteSpace(roomName))
                 return roomName.Trim();
             return LocalizationService.Translate(LocalizationService.Mark("game room"));
+        }
+
+        private static string ResolveTrackName(TrackPackageRef track, string trackName)
+        {
+            var display = MultiplayerCoordinator.FormatTrackDisplayName(track, trackName);
+            return string.IsNullOrWhiteSpace(display)
+                ? LocalizationService.Translate(LocalizationService.Mark("Unknown"))
+                : display;
         }
     }
 }

--- a/top_speed_net/TopSpeed/Core/Multiplayer/Domain/Online/Map.cs
+++ b/top_speed_net/TopSpeed/Core/Multiplayer/Domain/Online/Map.cs
@@ -53,8 +53,10 @@ namespace TopSpeed.Core.Multiplayer
         private static string ResolveRoomName(string roomName)
         {
             if (!string.IsNullOrWhiteSpace(roomName))
-                return roomName;
-            return MainRoomName;
+                return string.Equals(roomName.Trim(), MainRoomName, StringComparison.Ordinal)
+                    ? LocalizationService.Translate(MainRoomName)
+                    : roomName;
+            return LocalizationService.Translate(MainRoomName);
         }
 
         private static OnlinePresenceState NormalizePresence(OnlinePresenceState state)

--- a/top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options.cs
+++ b/top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options.cs
@@ -310,7 +310,7 @@ namespace TopSpeed.Core.Multiplayer
                 playersText);
         }
 
-        private static string ResolveTrackAnnouncement(TrackPackageRef track, string trackName)
+        internal static string FormatTrackDisplayName(TrackPackageRef track, string trackName)
         {
             var display = FormatTrackRefDisplay(track);
             if (!string.IsNullOrWhiteSpace(display))
@@ -323,6 +323,11 @@ namespace TopSpeed.Core.Multiplayer
             return string.IsNullOrWhiteSpace(fallback)
                 ? LocalizationService.Mark("Unknown")
                 : fallback;
+        }
+
+        private static string ResolveTrackAnnouncement(TrackPackageRef track, string trackName)
+        {
+            return FormatTrackDisplayName(track, trackName);
         }
 
         private void RebuildRoomTrackTypeMenu()


### PR DESCRIPTION
## What changed
- translate the online players list entry when the room name is the built-in \main room\
- reuse the existing built-in track display logic for \Track changed to {0}.\ room event history
- add localization behavior coverage for both cases

## Why
Issue #48 reports mixed translated/untranslated room text such as \main room\ and track-change notifications that still announce built-in track keys in English.

## Verification
- \dotnet test top_speed_net/TopSpeed.Tests/TopSpeed.Tests.csproj -c Debug --filter LocalizationBehaviorTests --no-restore\

Closes #48 items 5 and 7.