### PR TITLE
Resolve help docs by current language before falling back to English

### DIFF
--- a/top_speed_net/TopSpeed.Android/TopSpeed.Android.csproj
+++ b/top_speed_net/TopSpeed.Android/TopSpeed.Android.csproj
@@ -90,17 +90,8 @@
     <AndroidAsset Include="..\languages\server\**\*">
       <Link>languages/server/%(RecursiveDir)%(Filename)%(Extension)</Link>
     </AndroidAsset>
-    <AndroidAsset Include="$(RepoDocsDir)changes.html">
-      <Link>docs/changes.html</Link>
-    </AndroidAsset>
-    <AndroidAsset Include="$(RepoDocsDir)game-guide.html">
-      <Link>docs/game-guide.html</Link>
-    </AndroidAsset>
-    <AndroidAsset Include="$(RepoDocsDir)track-creation-guide.html">
-      <Link>docs/track-creation-guide.html</Link>
-    </AndroidAsset>
-    <AndroidAsset Include="$(RepoDocsDir)vehicle-physics-and-creation-guide.html">
-      <Link>docs/vehicle-physics-and-creation-guide.html</Link>
+    <AndroidAsset Include="$(RepoDocsDir)**\*.html">
+      <Link>docs/%(RecursiveDir)%(Filename)%(Extension)</Link>
     </AndroidAsset>
   </ItemGroup>
 

--- a/top_speed_net/TopSpeed.Tests/Behavior/Client/Menu/HelpDocumentResolverBehavior.cs
+++ b/top_speed_net/TopSpeed.Tests/Behavior/Client/Menu/HelpDocumentResolverBehavior.cs
@@ -1,0 +1,38 @@
+using System.Linq;
+using TopSpeed.Game;
+using Xunit;
+
+namespace TopSpeed.Tests;
+
+[Trait("Category", "Behavior")]
+public sealed class HelpDocumentResolverBehaviorTests
+{
+    [Fact]
+    public void BuildCandidateFileNames_ShouldPreferSpecificLanguageThenParentThenEnglish()
+    {
+        var candidates = HelpDocumentResolver.BuildCandidateFileNames("game-guide.html", "zh-CN");
+
+        candidates.Should().Equal(
+            "game-guide.zh-cn.html",
+            "game-guide.zh.html",
+            "game-guide.html");
+    }
+
+    [Fact]
+    public void BuildCandidateFileNames_ShouldFallbackToEnglishWhenLanguageMissing()
+    {
+        var candidates = HelpDocumentResolver.BuildCandidateFileNames("game-guide.html", null);
+
+        candidates.Should().Equal("game-guide.html");
+    }
+
+    [Fact]
+    public void BuildCandidateFileNames_ShouldAvoidDuplicateParentFallback()
+    {
+        var candidates = HelpDocumentResolver.BuildCandidateFileNames("game-guide.html", "zh");
+
+        candidates.Count.Should().Be(2);
+        candidates[0].Should().Be("game-guide.zh.html");
+        candidates.Last().Should().Be("game-guide.html");
+    }
+}

--- a/top_speed_net/TopSpeed/Game/Menu/Help.cs
+++ b/top_speed_net/TopSpeed/Game/Menu/Help.cs
@@ -35,7 +35,14 @@ namespace TopSpeed.Game
 
         private void OpenHelpDocument(string fileName)
         {
-            var path = AssetPaths.ResolveExistingPath("docs", fileName);
+            string? path = null;
+            foreach (var candidate in HelpDocumentResolver.BuildCandidateFileNames(fileName, _settings.Language))
+            {
+                path = AssetPaths.ResolveExistingPath("docs", candidate);
+                if (path != null)
+                    break;
+            }
+
             if (path == null)
             {
                 ShowMessageDialog(

--- a/top_speed_net/TopSpeed/Game/Menu/HelpDocumentResolver.cs
+++ b/top_speed_net/TopSpeed/Game/Menu/HelpDocumentResolver.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using TopSpeed.Localization;
+
+namespace TopSpeed.Game
+{
+    internal static class HelpDocumentResolver
+    {
+        public static IReadOnlyList<string> BuildCandidateFileNames(string fileName, string? languageCode)
+        {
+            var candidates = new List<string>();
+            AddLocalizedCandidates(candidates, fileName, languageCode);
+            AddUnique(candidates, fileName);
+            return candidates;
+        }
+
+        private static void AddLocalizedCandidates(List<string> candidates, string fileName, string? languageCode)
+        {
+            var normalized = LanguageCode.Normalize(languageCode);
+            if (string.IsNullOrWhiteSpace(normalized))
+                return;
+
+            var dotIndex = fileName.LastIndexOf('.');
+            if (dotIndex <= 0 || dotIndex >= fileName.Length - 1)
+            {
+                AddUnique(candidates, fileName + "." + normalized);
+            }
+            else
+            {
+                var stem = fileName.Substring(0, dotIndex);
+                var extension = fileName.Substring(dotIndex);
+                AddUnique(candidates, stem + "." + normalized + extension);
+
+                var parent = LanguageCode.ParentOf(normalized);
+                if (!string.IsNullOrWhiteSpace(parent) && !string.Equals(parent, normalized, System.StringComparison.OrdinalIgnoreCase))
+                    AddUnique(candidates, stem + "." + parent + extension);
+            }
+        }
+
+        private static void AddUnique(List<string> candidates, string fileName)
+        {
+            for (var i = 0; i < candidates.Count; i++)
+            {
+                if (string.Equals(candidates[i], fileName, System.StringComparison.OrdinalIgnoreCase))
+                    return;
+            }
+
+            candidates.Add(fileName);
+        }
+    }
+}


### PR DESCRIPTION
﻿## Summary

This updates the in-game help document lookup so help pages can follow the current language when localized HTML files are available.

## What changed

- added localized help document resolution for help pages
- fallback order is:
  - specific language, for example `game-guide.zh-cn.html`
  - parent language, for example `game-guide.zh.html`
  - default English document
- updated Android asset packaging to include all rendered `docs/**/*.html` files instead of a fixed list
- added tests for language fallback ordering

## Why

The help menu labels are already localized, but the actual help content always opens the English HTML files. This change adds the lookup mechanism needed for localized help docs without changing the current English fallback behavior.

## Verification

- validation passed across Windows, Linux, macOS, and Android
- tested fallback behavior with unit tests
