### PR TITLE
Fix three places that can't be translated

### DIFF
--- a/top_speed_net/TopSpeed/Game/Settings/VolumeShortcuts.cs
+++ b/top_speed_net/TopSpeed/Game/Settings/VolumeShortcuts.cs
@@ -159,7 +159,7 @@ namespace TopSpeed.Game
             var percent = GetVolumePercent(category);
             _speech.Speak(LocalizationService.Format(
                 LocalizationService.Mark("{0}: {1} percent"),
-                GetVolumeCategoryName(category),
+                LocalizationService.Translate(GetVolumeCategoryName(category)),
                 percent));
         }
 

--- a/top_speed_net/TopSpeed/Input/Mapping/Handler/Controller.cs
+++ b/top_speed_net/TopSpeed/Input/Mapping/Handler/Controller.cs
@@ -40,7 +40,7 @@ namespace TopSpeed.Input
                 : KeyMapManager.FormatAxis(axis);
             _speech.Speak(LocalizationService.Format(
                 LocalizationService.Mark("{0} set to {1}."),
-                label,
+                LocalizationService.Translate(label),
                 control));
         }
 

--- a/top_speed_net/TopSpeed/Input/Mapping/Handler/Keyboard.cs
+++ b/top_speed_net/TopSpeed/Input/Mapping/Handler/Keyboard.cs
@@ -86,7 +86,7 @@ namespace TopSpeed.Input
             var label = _driveInput.KeyMap.GetLabel(_mappingAction);
             _speech.Speak(LocalizationService.Format(
                 LocalizationService.Mark("{0} set to {1}."),
-                label,
+                LocalizationService.Translate(label),
                 KeyMapManager.FormatKey(key)));
             return true;
         }


### PR DESCRIPTION
### problem
Set up game keyboard mapping and controller mapping, press f6 and shift+f a part of the category hints of 6 cannot be translated, and the level displays the original text directly.
### What did I do
* 1. on top_speed_net\topspeed\input\mapping\handler\keyboard.Cs:line 89 plus LocalizationService.translate method.
* 2. on top_speed_net\topspeed\input\mapping\handler\controller.Cs:line 44 plus LocalizationService.translate method.
*3. on top_speed_net\topspeed\game\settings\VolumeShortcuts.cs:line 162 plus LocalizationService.translate method.
By adding this method, dynamically acquired categories and label can be translated correctly