### PR TITLE
Split track callouts from race info queue

### DIFF
--- a/top_speed_net/TopSpeed.Tests/Behavior/Client/Drive/TrackAudioBehavior.cs
+++ b/top_speed_net/TopSpeed.Tests/Behavior/Client/Drive/TrackAudioBehavior.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using TopSpeed.Data;
+using TopSpeed.Drive.Session;
+using TopSpeed.Drive.Session.Systems;
+using TopSpeed.Input;
+using TopSpeed.Tracks;
+using Xunit;
+
+namespace TopSpeed.Tests;
+
+[Trait("Category", "Behavior")]
+public sealed class TrackAudioBehaviorTests
+{
+    [Fact]
+    public void AnnounceNextRoad_Routes_Copilot_Callouts_To_Track_Info_Channel()
+    {
+        var settings = new DriveSettings
+        {
+            Copilot = CopilotMode.All
+        };
+        var soundIndexes = new List<int>();
+        var queuedTrackInfoSounds = 0;
+        var events = new List<Event>();
+        var delays = new List<float>();
+        var trackAudio = new TrackAudio(
+            settings,
+            index =>
+            {
+                soundIndexes.Add(index);
+                return null;
+            },
+            turnEndDing: null,
+            queueTrackInfoSound: _ => queuedTrackInfoSounds++,
+            queueEvent: (sessionEvent, delay) =>
+            {
+                events.Add(sessionEvent);
+                delays.Add(delay);
+            });
+
+        var currentRoad = new Track.Road
+        {
+            Type = TrackType.Straight,
+            Surface = TrackSurface.Asphalt
+        };
+        var nextRoad = new Track.Road
+        {
+            Type = TrackType.Left,
+            Surface = TrackSurface.Gravel
+        };
+
+        var announcedRoad = trackAudio.AnnounceNextRoad(currentRoad, nextRoad);
+
+        announcedRoad.Should().Be(nextRoad);
+        queuedTrackInfoSounds.Should().Be(1);
+        soundIndexes.Should().Equal((int)TrackType.Left - 1, (int)TrackSurface.Gravel + 8);
+        events.Should().ContainSingle();
+        events[0].Id.Should().Be(Events.PlayTrackInfoSound);
+        delays.Should().ContainSingle().Which.Should().Be(1.0f);
+    }
+}

--- a/top_speed_net/TopSpeed/Drive/Multiplayer/Session/Core/Core.cs
+++ b/top_speed_net/TopSpeed/Drive/Multiplayer/Session/Core/Core.cs
@@ -47,6 +47,7 @@ namespace TopSpeed.Drive.Multiplayer
             _finishLockController = new FinishLockInputController(input);
             _soundQueue = new Queue();
             _raceInfoQueue = new Queue();
+            _trackInfoQueue = new Queue();
             _manualTransmission = !automaticTransmission;
             _lapLimit = laps;
             _participants = new ParticipantState(MaxPlayers);

--- a/top_speed_net/TopSpeed/Drive/Multiplayer/Session/Core/Setup.cs
+++ b/top_speed_net/TopSpeed/Drive/Multiplayer/Session/Core/Setup.cs
@@ -62,7 +62,7 @@ namespace TopSpeed.Drive.Multiplayer
                 _settings,
                 GetRandomSoundBySlot,
                 _soundTurnEndDing,
-                QueueRaceInfoSound,
+                QueueTrackInfoSound,
                 (sessionEvent, delay) => _session!.QueueEvent(sessionEvent, delay));
 
             return new SubsystemSet(

--- a/top_speed_net/TopSpeed/Drive/Multiplayer/Session/Core/State.cs
+++ b/top_speed_net/TopSpeed/Drive/Multiplayer/Session/Core/State.cs
@@ -57,6 +57,7 @@ namespace TopSpeed.Drive.Multiplayer
         private readonly SessionRuntime _session;
         private readonly Queue _soundQueue;
         private readonly Queue _raceInfoQueue;
+        private readonly Queue _trackInfoQueue;
         private readonly ICarController _finishLockController;
         private readonly VehicleRadioController _localRadio;
         private readonly TopSpeed.Drive.Panels.RadioVehiclePanel _radioPanel;

--- a/top_speed_net/TopSpeed/Drive/Multiplayer/Session/Runtime/Audio.cs
+++ b/top_speed_net/TopSpeed/Drive/Multiplayer/Session/Runtime/Audio.cs
@@ -52,6 +52,12 @@ namespace TopSpeed.Drive.Multiplayer
                 _raceInfoQueue.Enqueue(sound);
         }
 
+        private void QueueTrackInfoSound(AudioSource? sound)
+        {
+            if (sound != null)
+                _trackInfoQueue.Enqueue(sound);
+        }
+
         private bool TrySendRace(bool sent)
         {
             if (sent)

--- a/top_speed_net/TopSpeed/Drive/Multiplayer/Session/Runtime/Dispose.cs
+++ b/top_speed_net/TopSpeed/Drive/Multiplayer/Session/Runtime/Dispose.cs
@@ -8,6 +8,7 @@ namespace TopSpeed.Drive.Multiplayer
         {
             _soundQueue.Clear();
             _raceInfoQueue.Clear();
+            _trackInfoQueue.Clear();
             _liveTx.Dispose();
             _panelManager.Dispose();
             _localRadio.Dispose();

--- a/top_speed_net/TopSpeed/Drive/Multiplayer/Session/Runtime/Flow.cs
+++ b/top_speed_net/TopSpeed/Drive/Multiplayer/Session/Runtime/Flow.cs
@@ -34,6 +34,9 @@ namespace TopSpeed.Drive.Multiplayer
                 case Events.PlayInfoSound:
                     QueueRaceInfoSound(sessionEvent.Data as TS.Audio.Source);
                     break;
+                case Events.PlayTrackInfoSound:
+                    QueueTrackInfoSound(sessionEvent.Data as TS.Audio.Source);
+                    break;
                 case Events.PlayUnkey:
                     _unkeyQueue--;
                     if (_unkeyQueue == 0)
@@ -52,6 +55,7 @@ namespace TopSpeed.Drive.Multiplayer
             {
                 _soundQueue.Pause();
                 _raceInfoQueue.Pause();
+                _trackInfoQueue.Pause();
                 _track.PauseAudio();
                 _car.Pause();
                 foreach (var remote in _remotePlayers.Values)
@@ -66,6 +70,7 @@ namespace TopSpeed.Drive.Multiplayer
             {
                 _soundQueue.Resume();
                 _raceInfoQueue.Resume();
+                _trackInfoQueue.Resume();
                 _track.ResumeAudio();
                 _car.Unpause();
                 foreach (var remote in _remotePlayers.Values)

--- a/top_speed_net/TopSpeed/Drive/Multiplayer/Session/Runtime/Initialize.cs
+++ b/top_speed_net/TopSpeed/Drive/Multiplayer/Session/Runtime/Initialize.cs
@@ -31,6 +31,7 @@ namespace TopSpeed.Drive.Multiplayer
             _localCrashCount = 0;
             _soundQueue.Clear();
             _raceInfoQueue.Clear();
+            _trackInfoQueue.Clear();
             _unkeyQueue = 0;
             _speakTime = 0f;
             _lap = 0;

--- a/top_speed_net/TopSpeed/Drive/Multiplayer/Session/Runtime/Results.cs
+++ b/top_speed_net/TopSpeed/Drive/Multiplayer/Session/Runtime/Results.cs
@@ -68,7 +68,7 @@ namespace TopSpeed.Drive.Multiplayer
                 return false;
             if (_requirePostFinishStopBeforeExit && !AreVehiclesSettledForExit())
                 return false;
-            if (!_soundQueue.IsIdle || !_raceInfoQueue.IsIdle)
+            if (!_soundQueue.IsIdle || !_raceInfoQueue.IsIdle || !_trackInfoQueue.IsIdle)
                 return false;
             if (_session.Context.Phase == Phase.Finishing)
                 _session.SetPhase(Phase.Finished);

--- a/top_speed_net/TopSpeed/Drive/Session/Events/Event.cs
+++ b/top_speed_net/TopSpeed/Drive/Session/Events/Event.cs
@@ -11,6 +11,7 @@ namespace TopSpeed.Drive.Session
         FinalizeResults,
         PlaySound,
         PlayInfoSound,
+        PlayTrackInfoSound,
         PlayUnkey
     }
 

--- a/top_speed_net/TopSpeed/Drive/Session/Events/Events.cs
+++ b/top_speed_net/TopSpeed/Drive/Session/Events/Events.cs
@@ -9,6 +9,7 @@ namespace TopSpeed.Drive.Session
         public const EventId FinalizeResults = EventId.FinalizeResults;
         public const EventId PlaySound = EventId.PlaySound;
         public const EventId PlayInfoSound = EventId.PlayInfoSound;
+        public const EventId PlayTrackInfoSound = EventId.PlayTrackInfoSound;
         public const EventId PlayUnkey = EventId.PlayUnkey;
     }
 }

--- a/top_speed_net/TopSpeed/Drive/Session/Systems/TrackAudio.cs
+++ b/top_speed_net/TopSpeed/Drive/Session/Systems/TrackAudio.cs
@@ -12,7 +12,7 @@ namespace TopSpeed.Drive.Session.Systems
         private readonly DriveSettings _settings;
         private readonly Func<int, Source?> _getRandomSound;
         private readonly Source? _turnEndDing;
-        private readonly Action<Source?> _queueSound;
+        private readonly Action<Source?> _queueTrackInfoSound;
         private readonly Action<Event, float> _queueEvent;
         private TrackType _lastRoadTypeAtPosition;
         private bool _hasLastRoadTypeAtPosition;
@@ -21,13 +21,13 @@ namespace TopSpeed.Drive.Session.Systems
             DriveSettings settings,
             Func<int, Source?> getRandomSound,
             Source? turnEndDing,
-            Action<Source?> queueSound,
+            Action<Source?> queueTrackInfoSound,
             Action<Event, float> queueEvent)
         {
             _settings = settings ?? throw new ArgumentNullException(nameof(settings));
             _getRandomSound = getRandomSound ?? throw new ArgumentNullException(nameof(getRandomSound));
             _turnEndDing = turnEndDing;
-            _queueSound = queueSound ?? throw new ArgumentNullException(nameof(queueSound));
+            _queueTrackInfoSound = queueTrackInfoSound ?? throw new ArgumentNullException(nameof(queueTrackInfoSound));
             _queueEvent = queueEvent ?? throw new ArgumentNullException(nameof(queueEvent));
             Reset();
         }
@@ -60,13 +60,13 @@ namespace TopSpeed.Drive.Session.Systems
             if ((int)_settings.Copilot > 0 && nextRoad.Type != TrackType.Straight)
             {
                 var index = (int)nextRoad.Type - 1;
-                _queueSound(_getRandomSound(index));
+                _queueTrackInfoSound(_getRandomSound(index));
             }
 
             if ((int)_settings.Copilot > 1 && nextRoad.Surface != currentRoad.Surface)
             {
                 var index = (int)nextRoad.Surface + 8;
-                _queueEvent(new Event(Events.PlayInfoSound, _getRandomSound(index)), 1.0f);
+                _queueEvent(new Event(Events.PlayTrackInfoSound, _getRandomSound(index)), 1.0f);
             }
 
             return nextRoad;

--- a/top_speed_net/TopSpeed/Drive/Single/Session/Audio.cs
+++ b/top_speed_net/TopSpeed/Drive/Single/Session/Audio.cs
@@ -58,6 +58,14 @@ namespace TopSpeed.Drive.Single
             _raceInfoQueue.Enqueue(sound);
         }
 
+        private void QueueTrackInfoSound(Source? sound)
+        {
+            if (sound == null)
+                return;
+
+            _trackInfoQueue.Enqueue(sound);
+        }
+
         private void RefreshCategoryVolumes()
         {
             var ambientPercent = _settings.AudioVolumes?.AmbientsAndSourcesPercent ?? 100;

--- a/top_speed_net/TopSpeed/Drive/Single/Session/Core.cs
+++ b/top_speed_net/TopSpeed/Drive/Single/Session/Core.cs
@@ -55,6 +55,7 @@ namespace TopSpeed.Drive.Single
         private readonly SessionRuntime _session;
         private readonly Queue _soundQueue;
         private readonly Queue _raceInfoQueue;
+        private readonly Queue _trackInfoQueue;
         private readonly ICarController _finishLockController;
         private readonly VehicleRadioController _localRadio;
         private readonly RadioVehiclePanel _radioPanel;
@@ -138,6 +139,7 @@ namespace TopSpeed.Drive.Single
             _raceAudio = new RaceAudioFactory(_audio);
             _soundQueue = new Queue();
             _raceInfoQueue = new Queue();
+            _trackInfoQueue = new Queue();
             _finishLockController = new FinishLockInputController(input);
             _manualTransmission = !automaticTransmission;
             _nComputerPlayers = Math.Min(settings.NrOfComputers, MaxComputerPlayers);
@@ -167,7 +169,7 @@ namespace TopSpeed.Drive.Single
             LoadRaceUiSounds();
             _soundStart = LoadLanguageSound("race\\start321");
 
-            _trackAudio = new TrackAudioService(_settings, GetRandomSoundBySlot, _soundTurnEndDing, QueueRaceInfoSound, (sessionEvent, delay) => _session!.QueueEvent(sessionEvent, delay));
+            _trackAudio = new TrackAudioService(_settings, GetRandomSoundBySlot, _soundTurnEndDing, QueueTrackInfoSound, (sessionEvent, delay) => _session!.QueueEvent(sessionEvent, delay));
             _panels = new PanelsSubsystem("panels", 110, _input, _panelManager, _radioPanel, SpeakText);
             _playerVehicle = new PlayerVehicleSubsystem(
                 "vehicle",

--- a/top_speed_net/TopSpeed/Drive/Single/Session/Lifecycle.cs
+++ b/top_speed_net/TopSpeed/Drive/Single/Session/Lifecycle.cs
@@ -34,6 +34,7 @@ namespace TopSpeed.Drive.Single
             _localCrashCount = 0;
             _soundQueue.Clear();
             _raceInfoQueue.Clear();
+            _trackInfoQueue.Clear();
             _unkeyQueue = 0;
             _speakTime = 0f;
             _lap = 0;
@@ -90,6 +91,7 @@ namespace TopSpeed.Drive.Single
         {
             _soundQueue.Clear();
             _raceInfoQueue.Clear();
+            _trackInfoQueue.Clear();
             _panelManager.Dispose();
             _localRadio.Dispose();
             _car.Dispose();
@@ -152,6 +154,9 @@ namespace TopSpeed.Drive.Single
                 case Events.PlayInfoSound:
                     QueueRaceInfoSound(sessionEvent.Data as Source);
                     break;
+                case Events.PlayTrackInfoSound:
+                    QueueTrackInfoSound(sessionEvent.Data as Source);
+                    break;
                 case Events.PlayUnkey:
                     _unkeyQueue--;
                     if (_unkeyQueue == 0)
@@ -171,6 +176,7 @@ namespace TopSpeed.Drive.Single
             {
                 _soundQueue.Pause();
                 _raceInfoQueue.Pause();
+                _trackInfoQueue.Pause();
                 _track.PauseAudio();
                 _soundTheme?.Play(loop: true);
                 FadeInTheme();
@@ -186,6 +192,7 @@ namespace TopSpeed.Drive.Single
             {
                 _soundQueue.Resume();
                 _raceInfoQueue.Resume();
+                _trackInfoQueue.Resume();
                 _track.ResumeAudio();
                 _car.Unpause();
                 for (var i = 0; i < _nComputerPlayers; i++)
@@ -230,7 +237,7 @@ namespace TopSpeed.Drive.Single
                 return false;
             if (_requirePostFinishStopBeforeExit && !AreVehiclesSettledForExit())
                 return false;
-            return _soundQueue.IsIdle && _raceInfoQueue.IsIdle;
+            return _soundQueue.IsIdle && _raceInfoQueue.IsIdle && _trackInfoQueue.IsIdle;
         }
 
         private float CalculateGridStartX(int gridIndex, float vehicleWidth, float startLineY)

--- a/top_speed_net/TopSpeed/Drive/TimeTrial/Session/Audio.cs
+++ b/top_speed_net/TopSpeed/Drive/TimeTrial/Session/Audio.cs
@@ -59,6 +59,14 @@ namespace TopSpeed.Drive.TimeTrial
             _raceInfoQueue.Enqueue(sound);
         }
 
+        private void QueueTrackInfoSound(Source? sound)
+        {
+            if (sound == null)
+                return;
+
+            _trackInfoQueue.Enqueue(sound);
+        }
+
         private void RefreshCategoryVolumes()
         {
             var ambientPercent = _settings.AudioVolumes?.AmbientsAndSourcesPercent ?? 100;

--- a/top_speed_net/TopSpeed/Drive/TimeTrial/Session/Core.cs
+++ b/top_speed_net/TopSpeed/Drive/TimeTrial/Session/Core.cs
@@ -51,6 +51,7 @@ namespace TopSpeed.Drive.TimeTrial
         private readonly SessionRuntime _session;
         private readonly Queue _soundQueue;
         private readonly Queue _raceInfoQueue;
+        private readonly Queue _trackInfoQueue;
         private readonly List<int> _lapTimes;
         private readonly string _trackId;
         private readonly int _nrOfLaps;
@@ -121,6 +122,7 @@ namespace TopSpeed.Drive.TimeTrial
             _scores = Store.CreateDefault();
             _soundQueue = new Queue();
             _raceInfoQueue = new Queue();
+            _trackInfoQueue = new Queue();
             _lapTimes = new List<int>();
             _finishLockController = new FinishLockInputController(input);
             _manualTransmission = !automaticTransmission;
@@ -145,7 +147,7 @@ namespace TopSpeed.Drive.TimeTrial
             _soundResume = LoadLanguageSound("race\\unpause");
             _soundTurnEndDing = LoadLegacySound("ding.ogg");
             PreloadRaceSpeechSources();
-            _trackAudio = new TrackAudioService(_settings, GetRandomSoundBySlot, _soundTurnEndDing, QueueRaceInfoSound, (sessionEvent, delay) => _session!.QueueEvent(sessionEvent, delay));
+            _trackAudio = new TrackAudioService(_settings, GetRandomSoundBySlot, _soundTurnEndDing, QueueTrackInfoSound, (sessionEvent, delay) => _session!.QueueEvent(sessionEvent, delay));
             _panels = new PanelsSubsystem("panels", 100, _input, _panelManager, _radioPanel, SpeakText);
             _playerVehicle = new PlayerVehicleSubsystem(
                 "vehicle",

--- a/top_speed_net/TopSpeed/Drive/TimeTrial/Session/Lifecycle.cs
+++ b/top_speed_net/TopSpeed/Drive/TimeTrial/Session/Lifecycle.cs
@@ -27,6 +27,7 @@ namespace TopSpeed.Drive.TimeTrial
             _lastLapRaceTimeMs = 0;
             _soundQueue.Clear();
             _raceInfoQueue.Clear();
+            _trackInfoQueue.Clear();
             _unkeyQueue = 0;
             _speakTime = 0f;
             _lap = 0;
@@ -75,6 +76,7 @@ namespace TopSpeed.Drive.TimeTrial
         {
             _soundQueue.Clear();
             _raceInfoQueue.Clear();
+            _trackInfoQueue.Clear();
             _panelManager.Dispose();
             _localRadio.Dispose();
             _car.Dispose();
@@ -105,7 +107,7 @@ namespace TopSpeed.Drive.TimeTrial
                 return false;
             if (_requirePostFinishStopBeforeExit && _car.Speed > PostFinishStopSpeedKph)
                 return false;
-            return _soundQueue.IsIdle && _raceInfoQueue.IsIdle;
+            return _soundQueue.IsIdle && _raceInfoQueue.IsIdle && _trackInfoQueue.IsIdle;
         }
 
         private void RequestExitWhenQueueIdle()

--- a/top_speed_net/TopSpeed/Drive/TimeTrial/Session/Loop.cs
+++ b/top_speed_net/TopSpeed/Drive/TimeTrial/Session/Loop.cs
@@ -40,6 +40,9 @@ namespace TopSpeed.Drive.TimeTrial
                 case Events.PlayInfoSound:
                     QueueRaceInfoSound(sessionEvent.Data as Source);
                     break;
+                case Events.PlayTrackInfoSound:
+                    QueueTrackInfoSound(sessionEvent.Data as Source);
+                    break;
                 case Events.PlayUnkey:
                     _unkeyQueue--;
                     if (_unkeyQueue == 0)
@@ -59,6 +62,7 @@ namespace TopSpeed.Drive.TimeTrial
             {
                 _soundQueue.Pause();
                 _raceInfoQueue.Pause();
+                _trackInfoQueue.Pause();
                 _track.PauseAudio();
                 _soundTheme?.Play(loop: true);
                 FadeInTheme();
@@ -72,6 +76,7 @@ namespace TopSpeed.Drive.TimeTrial
             {
                 _soundQueue.Resume();
                 _raceInfoQueue.Resume();
+                _trackInfoQueue.Resume();
                 _track.ResumeAudio();
                 _car.Unpause();
                 _panels.Resume();


### PR DESCRIPTION
## What changed

- Added a dedicated track info audio queue for copilot curve and surface callouts.
- Added `PlayTrackInfoSound` so delayed surface announcements no longer go through the general race info queue.
- Wired the new queue through single race, time trial, and multiplayer session lifecycle handling.
- Added a regression test for `TrackAudio` routing.

## Why

Curve and surface callouts were sharing the same FIFO race info queue as laps-to-go and finish announcements. That allowed time-sensitive track guidance to be delayed behind unrelated race info messages.

This change keeps race information serialized while giving track callouts their own channel, so they are no longer blocked by finish or lap announcements.

## Verification

- `dotnet test top_speed_net/TopSpeed.Tests/TopSpeed.Tests.csproj -c Debug -p:SkipTranslationCompilation=true`