### PR TITLE
Fix localized built-in track names in multiplayer room options

### DIFF
--- a/top_speed_net/TopSpeed.Tests/Behavior/Shared/Localization/LocalizationBehavior.cs
+++ b/top_speed_net/TopSpeed.Tests/Behavior/Shared/Localization/LocalizationBehavior.cs
@@ -108,6 +108,21 @@ namespace TopSpeed.Tests
             text.Should().Be("赛道已更改为 美国。");
         }
 
+        [Fact]
+        public void RoomTrackSelection_ShouldTranslateBuiltInTrackKey()
+        {
+            using var scope = LocalizationScope.Map(new Dictionary<string, string>
+            {
+                [TrackList.RaceTracks[0].Display] = "Localized America"
+            });
+
+            var text = MultiplayerCoordinator.FormatTrackDisplayName(
+                TrackPackageRef.BuiltIn(TrackList.RaceTracks[0].Key),
+                string.Empty);
+
+            text.Should().Be("Localized America");
+        }
+
         private sealed class LocalizationScope : IDisposable
         {
             private LocalizationScope(ITextLocalizer localizer)

--- a/top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/TrackSelection.cs
+++ b/top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/TrackSelection.cs
@@ -65,7 +65,7 @@ namespace TopSpeed.Core.Multiplayer
             for (var i = 0; i < tracks.Count; i++)
             {
                 var track = tracks[i];
-                items.Add(new MenuItem(track.Display, MenuAction.None, onActivate: () => SelectRoomTrack(TrackPackageRef.BuiltIn(track.Key), track.Display, false)));
+                items.Add(new MenuItem(track.Display, MenuAction.None, onActivate: () => SelectRoomTrack(TrackPackageRef.BuiltIn(track.Key), string.Empty, false)));
             }
 
             items.Add(new MenuItem(LocalizationService.Mark("Random"), MenuAction.None, onActivate: () => SelectRandomRoomTrackCategory(category)));


### PR DESCRIPTION
## What changed

- Updated multiplayer room track selection so built-in tracks are stored by track key instead of storing the current English display name.
- Kept the menu label behavior unchanged while allowing the selected track text to resolve through the existing localized track display lookup.
- Added a regression test covering localized built-in track display resolution for multiplayer room track selection.

## Why

In multiplayer room options, the initial built-in track display could be localized, but selecting a built-in track from the track menu stored the raw English display name. That caused the room option announcement to switch from localized text, for example `美国`, back to `America`.

This now matches the single race and time trial track selection pattern, where the menu item can display the track name but the selected value is stored by key and formatted later.

## Verification

- `dotnet build top_speed_net/TopSpeed.Tests/TopSpeed.Tests.csproj -c Debug --no-restore`
- `dotnet test top_speed_net/TopSpeed.Tests/TopSpeed.Tests.csproj -c Debug --no-build --filter RoomTrackSelection_ShouldTranslateBuiltInTrackKey`