### PR TITLE
Fix Chinese race result wording

### DIFF
--- a/top_speed_net/languages/client/zh-cn/messages.po
+++ b/top_speed_net/languages/client/zh-cn/messages.po
@@ -4808,7 +4808,7 @@ msgstr "你撞了 {0} 次。"
 #: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:154
 #, csharp-format
 msgid "You finished in {0}."
-msgstr "您以第{0}名完赛。"
+msgstr "您用时 {0} 完赛。"
 
 #: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:146
 msgid "You fought the course all the way through and still lost."
@@ -4894,7 +4894,7 @@ msgstr "本次最快单圈：{0}。"
 #: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:153
 #, csharp-format
 msgid "Your time: {0}."
-msgstr "你的时间：{0}。"
+msgstr "您的用时：{0}。"
 
 #: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:132
 msgid "Z minus"
@@ -5567,17 +5567,17 @@ msgstr "{0}，{1} 游戏，{2} 人，最多 {3} 名玩家"
 #: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:74
 #, csharp-format
 msgid "{0}: completed in position {1} with a time of {2}."
-msgstr "{0}：用时 {2}，获得第 {1} 名。"
+msgstr "{0}：第 {1} 名，用时 {2}。"
 
 #: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:68
 #, csharp-format
 msgid "{0}: crossed in position {1} after {2}."
-msgstr "{0}：用时 {2}，第 {1} 名冲线。"
+msgstr "{0}：第 {1} 名冲线，用时 {2}。"
 
 #: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:62
 #, csharp-format
 msgid "{0}: finished in position {1} with {2}."
-msgstr "{0}：用时 {2}，第 {1} 名完赛。"
+msgstr "{0}：第 {1} 名完赛，用时 {2}。"
 
 #: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:61
 #: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:67


### PR DESCRIPTION
## Summary

This fixes incorrect and inconsistent Chinese result wording in race and time trial result dialogs.

## What changed

- Fixed multiplayer race result variants so all templates report position before time consistently.
- Fixed the time trial template for `You finished in {0}.`; `{0}` is an elapsed time, not a finishing position.
- Updated `Your time: {0}.` to use consistent Chinese wording for elapsed time.

## Why

In Chinese, the race result dialog could mix these styles in one report:

- `第 1 名，用时 1 分钟23 秒`
- `用时 1 分钟37 秒，获得第 4 名`

The time trial dialog could also produce an incorrect sentence such as:

- `您以第3 分钟57 秒名完赛。`

That happened because `{0}` in `You finished in {0}.` is the elapsed time, but the Chinese translation treated it as a ranking.

## Verification

- `msgfmt --check --output-file=NUL top_speed_net/languages/client/zh-cn/messages.po`