### PR TITLE
Fix hard crash on startup when engine RPM data is missing from a vehicle .tsv

### DIFF
--- a/top_speed_net/TopSpeed/Vehicles/Parsing/Build/Validation/Core.cs
+++ b/top_speed_net/TopSpeed/Vehicles/Parsing/Build/Validation/Core.cs
@@ -22,84 +22,110 @@ namespace TopSpeed.Vehicles.Parsing
                 values.ShiftOnDemand,
                 issues);
 
-            if (values.MaxRpm < values.IdleRpm)
+            if (values.MaxRpm < values.IdleRpm
+                && TryEntryLine(sections.Engine, "max_rpm", out var maxRpmLine))
             {
                 issues.Add(new VehicleTsvIssue(
                     VehicleTsvIssueSeverity.Error,
-                    sections.Engine.Entries["max_rpm"].Line,
+                    maxRpmLine,
                     Localized("max_rpm must be greater than or equal to idle_rpm.")));
             }
 
-            if (values.RevLimiter < values.IdleRpm || values.RevLimiter > values.MaxRpm)
+            if ((values.RevLimiter < values.IdleRpm || values.RevLimiter > values.MaxRpm)
+                && TryEntryLine(sections.Engine, "rev_limiter", out var revLimiterLine))
             {
                 issues.Add(new VehicleTsvIssue(
                     VehicleTsvIssueSeverity.Error,
-                    sections.Engine.Entries["rev_limiter"].Line,
+                    revLimiterLine,
                     Localized("rev_limiter must be between idle_rpm and max_rpm.")));
             }
 
-            if (values.AutoShiftRpm > 0f && (values.AutoShiftRpm < values.IdleRpm || values.AutoShiftRpm > values.RevLimiter))
+            if (values.AutoShiftRpm > 0f
+                && (values.AutoShiftRpm < values.IdleRpm || values.AutoShiftRpm > values.RevLimiter)
+                && TryEntryLine(sections.Engine, "auto_shift_rpm", out var autoShiftRpmLine))
             {
                 issues.Add(new VehicleTsvIssue(
                     VehicleTsvIssueSeverity.Error,
-                    sections.Engine.Entries["auto_shift_rpm"].Line,
+                    autoShiftRpmLine,
                     Localized("auto_shift_rpm must be 0 or between idle_rpm and rev_limiter.")));
             }
 
-            if (values.PeakTorqueRpm < values.IdleRpm || values.PeakTorqueRpm > values.RevLimiter)
+            if ((values.PeakTorqueRpm < values.IdleRpm || values.PeakTorqueRpm > values.RevLimiter)
+                && TryEntryLine(sections.Torque, "peak_torque_rpm", out var peakTorqueRpmLine))
             {
                 issues.Add(new VehicleTsvIssue(
                     VehicleTsvIssueSeverity.Error,
-                    sections.Torque.Entries["peak_torque_rpm"].Line,
+                    peakTorqueRpmLine,
                     Localized("peak_torque_rpm must be between idle_rpm and rev_limiter.")));
             }
 
-            if (values.LaunchRpm > values.RevLimiter)
+            if (values.LaunchRpm > values.RevLimiter
+                && TryEntryLine(sections.Engine, "launch_rpm", out var launchRpmLine))
             {
                 issues.Add(new VehicleTsvIssue(
                     VehicleTsvIssueSeverity.Error,
-                    sections.Engine.Entries["launch_rpm"].Line,
+                    launchRpmLine,
                     Localized("launch_rpm must not exceed rev_limiter.")));
             }
 
-            if (values.TopFreq < values.IdleFreq)
+            if (values.TopFreq < values.IdleFreq
+                && TryEntryLine(sections.Sounds, "top_freq", out var topFreqLine))
             {
                 issues.Add(new VehicleTsvIssue(
                     VehicleTsvIssueSeverity.Error,
-                    sections.Sounds.Entries["top_freq"].Line,
+                    topFreqLine,
                     Localized("top_freq must be greater than or equal to idle_freq.")));
             }
 
-            if (values.ShiftFreq < values.IdleFreq || values.ShiftFreq > values.TopFreq)
+            if ((values.ShiftFreq < values.IdleFreq || values.ShiftFreq > values.TopFreq)
+                && TryEntryLine(sections.Sounds, "shift_freq", out var shiftFreqLine))
             {
                 issues.Add(new VehicleTsvIssue(
                     VehicleTsvIssueSeverity.Error,
-                    sections.Sounds.Entries["shift_freq"].Line,
+                    shiftFreqLine,
                     Localized("shift_freq must be between idle_freq and top_freq.")));
             }
 
-            if (float.IsNaN(values.PitchCurveExponent)
+            if ((float.IsNaN(values.PitchCurveExponent)
                 || float.IsInfinity(values.PitchCurveExponent)
                 || values.PitchCurveExponent < VehicleDefinition.PitchCurveExponentMin
                 || values.PitchCurveExponent > VehicleDefinition.PitchCurveExponentMax)
+                && TryEntryLine(sections.Sounds, "pitch_curve_exponent", out var pitchCurveLine))
             {
                 issues.Add(new VehicleTsvIssue(
                     VehicleTsvIssueSeverity.Error,
-                    sections.Sounds.Entries["pitch_curve_exponent"].Line,
+                    pitchCurveLine,
                     Localized(
                         "pitch_curve_exponent must be between {0} and {1}.",
                         VehicleDefinition.PitchCurveExponentMin,
                         VehicleDefinition.PitchCurveExponentMax)));
             }
 
-            if (values.HighSpeedSteerFullKph <= values.HighSpeedSteerStartKph)
+            if (values.HighSpeedSteerFullKph <= values.HighSpeedSteerStartKph
+                && TryEntryLine(sections.Steering, "high_speed_steer_full_kph", out var highSpeedSteerLine))
             {
                 issues.Add(new VehicleTsvIssue(
                     VehicleTsvIssueSeverity.Error,
-                    sections.Steering.Entries["high_speed_steer_full_kph"].Line,
+                    highSpeedSteerLine,
                     Localized("high_speed_steer_full_kph must be greater than high_speed_steer_start_kph.")));
             }
         }
+
+        // Resolves the source line for a key so a cross-field validation error can point at it.
+        // Returns false when the key is absent: in that case RequireFloatRange/RequireIntRange has
+        // already recorded a "missing required key" error (and optional keys fall back to a valid
+        // default), so the cross-field check is skipped rather than indexing a missing entry and
+        // throwing KeyNotFoundException.
+        private static bool TryEntryLine(Section section, string key, out int line)
+        {
+            if (section.Entries.TryGetValue(key, out var entry))
+            {
+                line = entry.Line;
+                return true;
+            }
+
+            line = 0;
+            return false;
+        }
     }
 }
-


### PR DESCRIPTION
## Problem

A custom vehicle `.tsv` that omits a required engine RPM key (e.g. `rev_limiter`) hard-crashes the game **on launch**, before the window is usable. Custom vehicle files are parsed at startup while building the custom-vehicle menu (`MenuRegistry.RegisterAll` → `BuildCustomVehicleItems` → `GetCustomVehicleInfo`), so a single bad file takes the whole game down with an unhandled `KeyNotFoundException`:

```
System.Collections.Generic.KeyNotFoundException: The given key 'rev_limiter' was not present in the dictionary.
   at TopSpeed.Vehicles.Parsing.VehicleTsvParser.ValidateResolvedValues(...) in .../Build/Validation/Core.cs:line 35
```

## Root cause

When a required key is absent, `RequireFloatRange`/`RequireIntRange` records a "missing required key" error **and substitutes a default value**. That default can still trip a *cross-field* range check in `ValidateResolvedValues` (for `rev_limiter`, the default `800` is below a normal `idle_rpm`). The check then indexes the section's `Entries` dictionary to fetch the source line for its error message — but the key isn't there, so the indexer throws and the exception is unhandled. This short-circuits the existing "skip the bad vehicle and report issues" path before it can run.

## Fix

Add `TryEntryLine`, which resolves the line via `TryGetValue` and returns `false` when the key is absent, and guard every cross-field check in `ValidateResolvedValues` with it (`rev_limiter`, `max_rpm`, `auto_shift_rpm`, `peak_torque_rpm`, `launch_rpm`, `top_freq`, `shift_freq`, `pitch_curve_exponent`, `high_speed_steer_full_kph` — they all shared the identical latent crash). A missing key now cleanly skips the redundant cross-field error; the "missing required key" error is already recorded and the vehicle is still skipped by `HasErrors`, so the user gets a clean error list instead of a crash.

One file, validation-only — does not touch the `VehicleTsvIssue` shape or the menu/dialog layer, so it's orthogonal to (and compatible with) the error/warning menu work on `feature-fuel-tires-pitting`.

## Testing

- Reproduced: a vehicle with `rev_limiter` removed and `idle_rpm=975` instacrashes on launch on the current `main`/feature code.
- Verified fixed: same file on this branch launches normally, skips the vehicle, and reports the issues (including `Missing required key 'rev_limiter'`).
- Core `TopSpeed` project builds with 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)