### PR TITLE
Fix multiplayer race never completing after an aborted race

### DIFF
--- a/top_speed_net/TopSpeed/Drive/Multiplayer/Session/Core/State.cs
+++ b/top_speed_net/TopSpeed/Drive/Multiplayer/Session/Core/State.cs
@@ -62,7 +62,7 @@ namespace TopSpeed.Drive.Multiplayer
         private readonly VehicleRadioController _localRadio;
         private readonly TopSpeed.Drive.Panels.RadioVehiclePanel _radioPanel;
         private readonly TopSpeed.Drive.Panels.VehiclePanelManager _panelManager;
-        private readonly uint _raceInstanceId;
+        private uint _raceInstanceId;
         private readonly Func<byte, string> _resolvePlayerName;
         private readonly int _lapLimit;
         private readonly ParticipantState _participants;

--- a/top_speed_net/TopSpeed/Drive/Multiplayer/Session/Runtime/Initialize.cs
+++ b/top_speed_net/TopSpeed/Drive/Multiplayer/Session/Runtime/Initialize.cs
@@ -112,6 +112,17 @@ namespace TopSpeed.Drive.Multiplayer
             _session.ApplyCommand(new SessionCommand(Commands.ClearPauseRequest));
         }
 
+        // Adopts the authoritative race instance from the server once it is known. After an abort the
+        // session can be created before the room/race-state packet re-binds the instance, leaving it
+        // at 0; every race packet we send then carries instance 0 and the server silently drops it
+        // (including our finish), so the race never completes. Self-healing to the real instance lets
+        // our outgoing packets be accepted again.
+        public void UpdateRaceInstanceId(uint raceInstanceId)
+        {
+            if (raceInstanceId != 0)
+                _raceInstanceId = raceInstanceId;
+        }
+
         public DriveResultSummary? ConsumeResultSummary()
         {
             var summary = _pendingResultSummary;

--- a/top_speed_net/TopSpeed/Game/Multiplayer/Race/Runtime.cs
+++ b/top_speed_net/TopSpeed/Game/Multiplayer/Race/Runtime.cs
@@ -60,11 +60,14 @@ namespace TopSpeed.Game
             {
                 _binding.ApplyRoomState(roomState);
                 _mode?.SetHostPaused(roomState.RacePaused);
+                _mode?.UpdateRaceInstanceId(_binding.RaceInstanceId);
             }
 
             public bool ApplyRaceState(TopSpeed.Protocol.PacketRoomRaceStateChanged changed)
             {
-                return _binding.ApplyRaceState(changed);
+                var applied = _binding.ApplyRaceState(changed);
+                _mode?.UpdateRaceInstanceId(_binding.RaceInstanceId);
+                return applied;
             }
 
             public bool MatchesRoom(uint roomId)


### PR DESCRIPTION
## Problem

Once any race in a room has been **aborted**, every subsequent race hangs: players cross the finish line and hear opponents finish, but never receive results and are stuck on the track (only horn / engine-start work). The host has to abort again to escape. The first race in a fresh room always completes correctly.

## Root cause

On abort teardown, the client race binding's `RaceInstanceId` is cleared to `0`. The `StartRace` event (on the `RaceEvent` stream) can be processed **before** the `RoomState` / `RoomRaceStateChanged` packet that re-binds the instance. The new `MultiplayerSession` is then created with `RaceInstanceId == 0`, so every race packet it sends — `PlayerData`, `PlayerStarted`, and crucially `PlayerState = Finished` — fails the server's first `ValidatePacket` check (`!IsValidRaceInstance(0)`) and is **silently dropped** (no mismatch log).

The server therefore never records the human's finish and the race sits at `finished=1/2` forever. Verified from a full-verbosity server log: in the post-abort race the bot's finish is recorded but the human's never is, with no `payload mismatch` / `race instance mismatch` lines (those only fire for a *non-zero stale* instance).

## Fix

Let the running session **self-heal** its `RaceInstanceId` from the authoritative `RoomState` / `RoomRaceStateChanged` stream it keeps receiving during the race:

- `_raceInstanceId` is made mutable and gains `UpdateRaceInstanceId(uint)` (ignores 0).
- `MultiplayerRaceRuntime.ApplyRoomState` / `ApplyRaceState` push the binding's current instance into the session after each update.

The server's room event sequence is monotonic across the room's lifetime (`RoomEventJournal.ClearForRaceStart` clears only the replay journal, not `room.EventSequence`), so the post-abort race's state packets are not rejected as stale — the binding reliably learns the new instance and the session adopts it, so its outgoing finish is accepted and the race completes.

Minimal and safe: no change to the race-start flow (so it cannot hang *at* start), and it's a no-op in the normal case where the instance is already correct.

## Testing

- Builds clean; full test suite passes (428/428).
- Manually verified: reproduced the abort → restart hang, applied the fix, and subsequent races now complete and return to the room menu.