### PR TITLE
Fix being bumped by bots after finishing a single race

### DIFF
--- a/top_speed_net/TopSpeed/Drive/Single/Session/Core.cs
+++ b/top_speed_net/TopSpeed/Drive/Single/Session/Core.cs
@@ -291,7 +291,7 @@ namespace TopSpeed.Drive.Single
                 value => _positionComment = value,
                 SpeakIfLoaded,
                 Speak);
-            _collisions = new CollisionsSubsystem("collisions", 150, _track, _car, _computerPlayers, () => _playerNumber, () => _nComputerPlayers, () => _pitStop!.IsGhosted);
+            _collisions = new CollisionsSubsystem("collisions", 150, _track, _car, _computerPlayers, () => _playerNumber, () => _nComputerPlayers, () => _pitStop!.IsGhosted, () => _finished);
             _pitStop = new PitStopSubsystem(
                 "pitStop",
                 135,

--- a/top_speed_net/TopSpeed/Drive/Single/Session/Core.cs
+++ b/top_speed_net/TopSpeed/Drive/Single/Session/Core.cs
@@ -291,7 +291,7 @@ namespace TopSpeed.Drive.Single
                 value => _positionComment = value,
                 SpeakIfLoaded,
                 Speak);
-            _collisions = new CollisionsSubsystem("collisions", 150, _track, _car, _computerPlayers, () => _playerNumber, () => _nComputerPlayers, () => _pitStop!.IsGhosted, () => _finished);
+            _collisions = new CollisionsSubsystem("collisions", 150, _track, _car, _computerPlayers, () => _playerNumber, () => _nComputerPlayers, () => _pitStop!.IsGhosted, () => _finished, () => _started);
             _pitStop = new PitStopSubsystem(
                 "pitStop",
                 135,

--- a/top_speed_net/TopSpeed/Drive/Single/Session/Systems/Collisions.cs
+++ b/top_speed_net/TopSpeed/Drive/Single/Session/Systems/Collisions.cs
@@ -34,6 +34,7 @@ namespace TopSpeed.Drive.Single.Session.Systems
         private readonly Func<int> _getPlayerCount;
         private readonly Func<bool> _isInPitStop;
         private readonly Func<bool> _isFinished;
+        private readonly Func<bool> _isStarted;
         private readonly HashSet<ulong> _activePairs = new HashSet<ulong>();
 
         public Collisions(
@@ -45,7 +46,8 @@ namespace TopSpeed.Drive.Single.Session.Systems
             Func<int> getPlayerNumber,
             Func<int> getPlayerCount,
             Func<bool> isInPitStop,
-            Func<bool> isFinished)
+            Func<bool> isFinished,
+            Func<bool> isStarted)
             : base(name, order)
         {
             _track = track ?? throw new ArgumentNullException(nameof(track));
@@ -55,17 +57,24 @@ namespace TopSpeed.Drive.Single.Session.Systems
             _getPlayerCount = getPlayerCount ?? throw new ArgumentNullException(nameof(getPlayerCount));
             _isInPitStop = isInPitStop ?? throw new ArgumentNullException(nameof(isInPitStop));
             _isFinished = isFinished ?? throw new ArgumentNullException(nameof(isFinished));
+            _isStarted = isStarted ?? throw new ArgumentNullException(nameof(isStarted));
         }
 
         public override void Update(TopSpeed.Drive.Session.SessionContext context, float elapsed)
         {
+            // Collisions only exist once the race is underway; before the start the field is packed
+            // together on the grid, so contact there would be spurious. This single gate replaces the
+            // per-car "is running" checks that used to keep grid-bound cars apart as a side effect.
+            if (!_isStarted())
+                return;
+
             var roadModel = ResolveRoadModel();
             var actors = new List<Actor>(_getPlayerCount() + 1);
             var activePairs = new HashSet<ulong>();
 
-            // A finished or pitting (ghosted) player is untouchable; otherwise the player is a
-            // collision target regardless of engine state. Sitting still with the engine off, coasting,
-            // stalled, or crashed and not yet restarted all remain hittable by bots still racing.
+            // A car is a collision target unless it is finished (or, for the player, pitting/ghosted).
+            // Engine state is irrelevant: sitting still with the engine off, coasting, stalled, or
+            // crashed and not yet restarted all remain hittable by cars still racing.
             if (!_isInPitStop() && !_isFinished())
                 actors.Add(new Actor((uint)_getPlayerNumber(), isPlayer: true, bot: null));
 
@@ -75,7 +84,7 @@ namespace TopSpeed.Drive.Single.Session.Systems
                 if (bot == null)
                     continue;
 
-                if (bot.State == ComputerPlayer.ComputerState.Running && !bot.Finished)
+                if (!bot.Finished)
                     actors.Add(new Actor((uint)bot.PlayerNumber, isPlayer: false, bot: bot));
             }
 

--- a/top_speed_net/TopSpeed/Drive/Single/Session/Systems/Collisions.cs
+++ b/top_speed_net/TopSpeed/Drive/Single/Session/Systems/Collisions.cs
@@ -33,6 +33,7 @@ namespace TopSpeed.Drive.Single.Session.Systems
         private readonly Func<int> _getPlayerNumber;
         private readonly Func<int> _getPlayerCount;
         private readonly Func<bool> _isInPitStop;
+        private readonly Func<bool> _isFinished;
         private readonly HashSet<ulong> _activePairs = new HashSet<ulong>();
 
         public Collisions(
@@ -43,7 +44,8 @@ namespace TopSpeed.Drive.Single.Session.Systems
             ComputerPlayer?[] players,
             Func<int> getPlayerNumber,
             Func<int> getPlayerCount,
-            Func<bool> isInPitStop)
+            Func<bool> isInPitStop,
+            Func<bool> isFinished)
             : base(name, order)
         {
             _track = track ?? throw new ArgumentNullException(nameof(track));
@@ -52,6 +54,7 @@ namespace TopSpeed.Drive.Single.Session.Systems
             _getPlayerNumber = getPlayerNumber ?? throw new ArgumentNullException(nameof(getPlayerNumber));
             _getPlayerCount = getPlayerCount ?? throw new ArgumentNullException(nameof(getPlayerCount));
             _isInPitStop = isInPitStop ?? throw new ArgumentNullException(nameof(isInPitStop));
+            _isFinished = isFinished ?? throw new ArgumentNullException(nameof(isFinished));
         }
 
         public override void Update(TopSpeed.Drive.Session.SessionContext context, float elapsed)
@@ -60,7 +63,10 @@ namespace TopSpeed.Drive.Single.Session.Systems
             var actors = new List<Actor>(_getPlayerCount() + 1);
             var activePairs = new HashSet<ulong>();
 
-            if (_car.State == Vehicles.CarState.Running && !_isInPitStop())
+            // A finished or pitting (ghosted) player is untouchable; otherwise the player is a
+            // collision target regardless of engine state. Sitting still with the engine off, coasting,
+            // stalled, or crashed and not yet restarted all remain hittable by bots still racing.
+            if (!_isInPitStop() && !_isFinished())
                 actors.Add(new Actor((uint)_getPlayerNumber(), isPlayer: true, bot: null));
 
             for (var i = 0; i < _getPlayerCount(); i++)


### PR DESCRIPTION
Fixes #130.

## Problem

After finishing a single-race event ahead of the AI, you could still be bumped by bots crossing the finish line — by idling on the line with the engine running, by restarting your engine there, or occasionally right as you finished. Getting hit locked you into an uncontrollable drift (you could sometimes steer/honk but not drive), and the race wouldn't end until you happened to coast back to a stop.

## Root cause

The single-race collision system added the player as a collision target whenever the car was in `CarState.Running`, with no check for whether the player had already finished. Finishing shuts the engine down but does **not** immediately change `CarState`, and the engine can be restarted on the line — so a finished player kept being treated as a live racer and remained hittable.

## Fix

Collision eligibility is decoupled from engine state entirely:

- A car — player or bot — is a collision target only while the race is **underway** and it has **not finished** (the player additionally excludes pitting/ghosted, since only the player can pit).
- An explicit **race-underway gate** was added so the field packed together on the starting grid can't generate spurious contact. This replaces the per-car "is running" checks that were quietly doing that job as a side effect.
- Bots now use the same `!finished` rule as the player, so stopped and crashed cars are consistently hittable mid-race instead of the player's wreck being hittable while a bot's is not.

Net result: once you finish, you're untouchable regardless of engine state; before that, engine on/off/stalled/crashed no longer changes whether you can be hit.

## Scope — single race only

The issue asked to reproduce in **single race mode** and noted that the behavior in multiplayer was unknown. This bug is specific to single race, and **from reading the code, multiplayer does not appear to be affected**: server-authoritative collisions there key on `PlayerState.Racing`, which never couples to engine/stop/crash and transitions to a sticky `Finished` on completion, and the bots follow the same rule. This was verified by **code inspection only — not playtested**, so the multiplayer conclusion is a code-reading claim rather than a tested one.

## Testing

- Full test suite passes (525/525).
- Single-race playtesting: finishing ahead of the pack and sitting on the line (engine running / restarted) no longer results in bumps, and the race ends normally.
