### PR TITLE
Handle missing custom-vehicle sounds instead of hard-crashing

### DIFF
--- a/docs/en/changes.md
+++ b/docs/en/changes.md
@@ -5,6 +5,11 @@ This file tracks new changes to the game for both client and server to make it e
 The game versioning follows a specific pattern by using year.month.day.revision, where revision is an incremental number if there is more than one release in a single day.
 
 
+## 2026.7.17.1
+### Game Changes
+- Fixed a crash that could happen when starting a race with a custom vehicle that was missing one of its sound files. The vehicle now stays playable: any missing sound is replaced with a built-in default (or, for optional sounds, simply left silent), and the custom vehicles menu shows a warning describing what was missing.
+
+
 ## 2026.7.15.1
 ### Game Changes
 - Fixed a single race bug where the computer cars could still bump into you after you had already finished the race, such as while waiting on the finish line with your engine running. Being hit could leave your car sliding out of your control and could delay the end of the race.

--- a/info.json
+++ b/info.json
@@ -1,7 +1,8 @@
 {
-  "version": "2026.7.15.1",
+  "version": "2026.7.17.1",
   "serverVersion": "2026.7.15.1",
   "changes": [
+    "Fixed a crash that could happen when starting a race with a custom vehicle that was missing one of its sound files. The vehicle now stays playable: any missing sound is replaced with a built-in default (or, for optional sounds, simply left silent), and the custom vehicles menu shows a warning describing what was missing.",
     "Fixed a single race bug where the computer cars could still bump into you after you had already finished the race, such as while waiting on the finish line with your engine running. Being hit could leave your car sliding out of your control and could delay the end of the race.",
     "Removed some unused sound files that were bundled with the non-English language packs."
   ],

--- a/top_speed_net/TopSpeed.Shared/Protocol/VersionInfo.cs
+++ b/top_speed_net/TopSpeed.Shared/Protocol/VersionInfo.cs
@@ -6,7 +6,7 @@ namespace TopSpeed.Protocol
         // Client release version used by updater checks and release packaging.
         public const ushort ClientYear = 2026;
         public const byte ClientMonth = 7;
-        public const byte ClientDay = 15;
+        public const byte ClientDay = 17;
         public const byte ClientRevision = 1;
 
         // Server release version used by updater checks and packaging.

--- a/top_speed_net/TopSpeed.Tests/Behavior/Client/Vehicles/CustomSoundValidationBehavior.cs
+++ b/top_speed_net/TopSpeed.Tests/Behavior/Client/Vehicles/CustomSoundValidationBehavior.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using TopSpeed.Protocol;
+using TopSpeed.Vehicles.Loader;
+using TopSpeed.Vehicles.Parsing;
+using Xunit;
+
+namespace TopSpeed.Tests
+{
+    // Guards Sound.ValidateCustomSounds, the check the custom-vehicles menu runs on entry so a car that
+    // references a sound file it never shipped is flagged up front instead of only surfacing at the race
+    // loader. The Required flag no longer gates selection (the car stays playable via the loader's fallback);
+    // it drives the wording of the warning line ("required sound" vs "optional sound"). The value here is
+    // behavioral: a regression would still compile but misclassify a slot and mislabel the warning.
+    [Trait("Category", "Behavior")]
+    public sealed class CustomSoundValidationBehaviorTests
+    {
+        [Fact]
+        public void AllRequiredSoundsPresent_ShouldProduceNoIssues()
+        {
+            using var vehicle = TempVehicleFolder.Create("engine.wav", "start.wav", "horn.wav", "brake.wav", "crash.wav");
+            var sounds = new CustomVehicleSounds
+            {
+                Engine = "engine.wav",
+                Start = "start.wav",
+                Horn = "horn.wav",
+                Brake = "brake.wav",
+                CrashVariants = new[] { "crash.wav" }
+            };
+
+            var issues = Sound.ValidateCustomSounds(sounds, vehicle.BuiltinRoot, vehicle.Path);
+
+            issues.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void MissingRequiredEngine_ShouldReportRequiredIssue()
+        {
+            // The .tsv names an engine sound that is not on disk (a .tsv that shipped without its .wav).
+            using var vehicle = TempVehicleFolder.Create("start.wav", "horn.wav", "brake.wav", "crash.wav");
+            var sounds = new CustomVehicleSounds
+            {
+                Engine = "missing_engine.wav",
+                Start = "start.wav",
+                Horn = "horn.wav",
+                Brake = "brake.wav",
+                CrashVariants = new[] { "crash.wav" }
+            };
+
+            var issues = Sound.ValidateCustomSounds(sounds, vehicle.BuiltinRoot, vehicle.Path);
+
+            issues.Should().ContainSingle();
+            issues[0].Action.Should().Be(VehicleAction.Engine);
+            issues[0].Required.Should().BeTrue();
+            issues[0].Message.Should().Contain("missing_engine.wav");
+            issues[0].MissingPath.Should().NotBeNullOrEmpty();
+            issues[0].MissingPath.Should().Contain("missing_engine.wav");
+        }
+
+        [Fact]
+        public void MissingOptionalStop_ShouldReportWarningNotRequired()
+        {
+            using var vehicle = TempVehicleFolder.Create("engine.wav", "start.wav", "horn.wav", "brake.wav", "crash.wav");
+            var sounds = new CustomVehicleSounds
+            {
+                Engine = "engine.wav",
+                Start = "start.wav",
+                Horn = "horn.wav",
+                Brake = "brake.wav",
+                CrashVariants = new[] { "crash.wav" },
+                Stop = "stop.wav" // declared but never shipped
+            };
+
+            var issues = Sound.ValidateCustomSounds(sounds, vehicle.BuiltinRoot, vehicle.Path);
+
+            issues.Should().ContainSingle();
+            issues[0].Action.Should().Be(VehicleAction.Stop);
+            issues[0].Required.Should().BeFalse();
+        }
+
+        [Fact]
+        public void CrashListWithOneSurvivingVariant_ShouldNotBeRequired()
+        {
+            // A single resolvable crash variant is enough to run, so the missing sibling must not escalate the
+            // whole slot to a required error that would drop the car from the menu.
+            using var vehicle = TempVehicleFolder.Create("engine.wav", "start.wav", "horn.wav", "brake.wav", "crash2.wav");
+            var sounds = new CustomVehicleSounds
+            {
+                Engine = "engine.wav",
+                Start = "start.wav",
+                Horn = "horn.wav",
+                Brake = "brake.wav",
+                CrashVariants = new[] { "crash1.wav", "crash2.wav" }
+            };
+
+            var issues = Sound.ValidateCustomSounds(sounds, vehicle.BuiltinRoot, vehicle.Path);
+
+            issues.Should().ContainSingle();
+            issues[0].Action.Should().Be(VehicleAction.Crash);
+            issues[0].Required.Should().BeFalse();
+            issues.Any(x => x.Required).Should().BeFalse("one good crash variant keeps the car playable");
+        }
+
+        [Fact]
+        public void CrashListWithNoVariants_ShouldBeRequired()
+        {
+            using var vehicle = TempVehicleFolder.Create("engine.wav", "start.wav", "horn.wav", "brake.wav");
+            var sounds = new CustomVehicleSounds
+            {
+                Engine = "engine.wav",
+                Start = "start.wav",
+                Horn = "horn.wav",
+                Brake = "brake.wav",
+                CrashVariants = Array.Empty<string>()
+            };
+
+            var issues = Sound.ValidateCustomSounds(sounds, vehicle.BuiltinRoot, vehicle.Path);
+
+            issues.Should().ContainSingle();
+            issues[0].Action.Should().Be(VehicleAction.Crash);
+            issues[0].Required.Should().BeTrue();
+        }
+
+        [Fact]
+        public void BuiltinReferences_ShouldNotBeFlaggedAsMissing()
+        {
+            // Cars that point required slots at builtins must not be flagged just because they carry no local
+            // .wav of their own. Builtin1 resolves via the official fallback files.
+            using var vehicle = TempVehicleFolder.Create();
+            vehicle.CreateBuiltinVehicle("Vehicle1", "engine.wav", "start.wav", "horn.wav", "brake.wav", "crash.wav");
+            var sounds = new CustomVehicleSounds
+            {
+                Engine = "builtin1",
+                Start = "builtin1",
+                Horn = "builtin1",
+                Brake = "builtin1",
+                CrashVariants = new[] { "builtin1" }
+            };
+
+            var issues = Sound.ValidateCustomSounds(sounds, vehicle.BuiltinRoot, vehicle.Path);
+
+            issues.Should().BeEmpty();
+        }
+
+        private sealed class TempVehicleFolder : IDisposable
+        {
+            public string Root { get; }
+            public string Path { get; }
+            public string BuiltinRoot { get; }
+
+            private TempVehicleFolder(string root, string vehiclePath, string builtinRoot)
+            {
+                Root = root;
+                Path = vehiclePath;
+                BuiltinRoot = builtinRoot;
+            }
+
+            public static TempVehicleFolder Create(params string[] existingFiles)
+            {
+                var root = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"topspeed_sounds_{Guid.NewGuid():N}");
+                var vehicleDir = System.IO.Path.Combine(root, "vehicle");
+                var builtinDir = System.IO.Path.Combine(root, "builtin");
+                Directory.CreateDirectory(vehicleDir);
+                Directory.CreateDirectory(builtinDir);
+                for (var i = 0; i < existingFiles.Length; i++)
+                    File.WriteAllBytes(System.IO.Path.Combine(vehicleDir, existingFiles[i]), Array.Empty<byte>());
+                return new TempVehicleFolder(root, vehicleDir, builtinDir);
+            }
+
+            public void CreateBuiltinVehicle(string folder, params string[] files)
+            {
+                var dir = System.IO.Path.Combine(BuiltinRoot, folder);
+                Directory.CreateDirectory(dir);
+                for (var i = 0; i < files.Length; i++)
+                    File.WriteAllBytes(System.IO.Path.Combine(dir, files[i]), Array.Empty<byte>());
+            }
+
+            public void Dispose()
+            {
+                try
+                {
+                    if (Directory.Exists(Root))
+                        Directory.Delete(Root, recursive: true);
+                }
+                catch (IOException)
+                {
+                    // Best-effort cleanup; a leftover temp folder must not fail the test.
+                }
+            }
+        }
+    }
+}

--- a/top_speed_net/TopSpeed/Core/Selection/VehicleSource.cs
+++ b/top_speed_net/TopSpeed/Core/Selection/VehicleSource.cs
@@ -34,6 +34,37 @@ namespace TopSpeed.Core
             if (issues != null && issues.Count > 0)
                 AppendIssues(file, issues);
 
+            // The .tsv parsed, but it may reference sound files that are not on disk (a common packaging
+            // mistake: the .tsv ships without its .wav). Surface that here, up front, instead of letting the
+            // race loader hit it later. Both required and optional missing sounds are warnings only: the car
+            // stays selectable and playable because the loader substitutes a built-in default for a missing
+            // required sound and simply skips a missing optional one. The line states which it is.
+            var builtinRoot = System.IO.Path.Combine(AssetPaths.SoundsRoot, "Vehicles");
+            var soundIssues = Vehicles.Loader.Sound.ValidateCustomSounds(parsed.Sounds, builtinRoot, parsed.SourceDirectory);
+            if (soundIssues.Count > 0)
+            {
+                AddFileIssue(file);
+                var warning = LocalizationService.Translate(LocalizationService.Mark("Warning"));
+                for (var i = 0; i < soundIssues.Count; i++)
+                {
+                    var issue = soundIssues[i];
+
+                    // When it is a missing file we name the path; for a malformed/unsafe reference we show
+                    // the reason instead. Either way we state what the game will do about it.
+                    string body;
+                    if (!string.IsNullOrEmpty(issue.MissingPath))
+                        body = issue.Required
+                            ? LocalizationService.Format(LocalizationService.Mark("required sound not found, will use built in fallback: {0}"), issue.MissingPath)
+                            : LocalizationService.Format(LocalizationService.Mark("optional sound not found, no sound will play: {0}"), issue.MissingPath);
+                    else
+                        body = issue.Required
+                            ? LocalizationService.Format(LocalizationService.Mark("required sound problem, will use built in fallback: {0}"), issue.Message)
+                            : LocalizationService.Format(LocalizationService.Mark("optional sound problem, no sound will play: {0}"), issue.Message);
+
+                    AddIssue(LocalizationService.Format(LocalizationService.Mark("{0}: {1}"), warning, body));
+                }
+            }
+
             var info = new CustomVehicleInfo(
                 file,
                 string.IsNullOrWhiteSpace(parsed.Meta.Name) ? LocalizationService.Mark("Custom vehicle") : parsed.Meta.Name,

--- a/top_speed_net/TopSpeed/Vehicles/loader/Custom.cs
+++ b/top_speed_net/TopSpeed/Vehicles/loader/Custom.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using TopSpeed.Core;
 using TopSpeed.Data;
@@ -41,19 +42,76 @@ namespace TopSpeed.Vehicles.Loader
             };
             Spec.Apply(def, spec);
 
-            def.SetSoundPath(VehicleAction.Engine, Sound.ResolveCustom(parsed.Sounds.Engine, builtinRoot, parsed.SourceDirectory, VehicleAction.Engine));
-            def.SetSoundPath(VehicleAction.Start, Sound.ResolveCustom(parsed.Sounds.Start, builtinRoot, parsed.SourceDirectory, VehicleAction.Start));
+            var vehicleRoot = parsed.SourceDirectory;
+
+            // Required sounds fall back to the official builtin equivalent when a custom file is missing or
+            // unresolvable, so a mispackaged vehicle (e.g. a .tsv that references a .wav that never shipped)
+            // degrades to a working car instead of hard-crashing the race. The custom-vehicles menu already
+            // flags these up front; this is the last line of defence for a car reached another way.
+            def.SetSoundPath(VehicleAction.Engine, ResolveRequired(parsed.Sounds.Engine, builtinRoot, vehicleRoot, VehicleAction.Engine));
+            def.SetSoundPath(VehicleAction.Start, ResolveRequired(parsed.Sounds.Start, builtinRoot, vehicleRoot, VehicleAction.Start));
             if (!string.IsNullOrWhiteSpace(parsed.Sounds.Stop))
-                def.SetSoundPath(VehicleAction.Stop, Sound.ResolveCustom(parsed.Sounds.Stop!, builtinRoot, parsed.SourceDirectory, VehicleAction.Stop));
-            def.SetSoundPath(VehicleAction.Horn, Sound.ResolveCustom(parsed.Sounds.Horn, builtinRoot, parsed.SourceDirectory, VehicleAction.Horn));
+                SetOptional(def, VehicleAction.Stop, parsed.Sounds.Stop!, builtinRoot, vehicleRoot);
+            def.SetSoundPath(VehicleAction.Horn, ResolveRequired(parsed.Sounds.Horn, builtinRoot, vehicleRoot, VehicleAction.Horn));
             if (!string.IsNullOrWhiteSpace(parsed.Sounds.Throttle))
-                def.SetSoundPath(VehicleAction.Throttle, Sound.ResolveCustom(parsed.Sounds.Throttle!, builtinRoot, parsed.SourceDirectory, VehicleAction.Throttle));
-            def.SetSoundPath(VehicleAction.Brake, Sound.ResolveCustom(parsed.Sounds.Brake, builtinRoot, parsed.SourceDirectory, VehicleAction.Brake));
-            def.SetSoundPaths(VehicleAction.Crash, Sound.ResolveCustomList(parsed.Sounds.CrashVariants, builtinRoot, parsed.SourceDirectory, VehicleAction.Crash));
+                SetOptional(def, VehicleAction.Throttle, parsed.Sounds.Throttle!, builtinRoot, vehicleRoot);
+            def.SetSoundPath(VehicleAction.Brake, ResolveRequired(parsed.Sounds.Brake, builtinRoot, vehicleRoot, VehicleAction.Brake));
+            def.SetSoundPaths(VehicleAction.Crash, ResolveRequiredList(parsed.Sounds.CrashVariants, builtinRoot, vehicleRoot, VehicleAction.Crash));
             if (parsed.Sounds.BackfireVariants != null && parsed.Sounds.BackfireVariants.Count > 0)
-                def.SetSoundPaths(VehicleAction.Backfire, Sound.ResolveCustomList(parsed.Sounds.BackfireVariants, builtinRoot, parsed.SourceDirectory, VehicleAction.Backfire));
+            {
+                var backfire = ResolveOptionalList(parsed.Sounds.BackfireVariants, builtinRoot, vehicleRoot, VehicleAction.Backfire);
+                if (backfire.Length > 0)
+                    def.SetSoundPaths(VehicleAction.Backfire, backfire);
+            }
 
             return def;
+        }
+
+        private static string ResolveRequired(string value, string builtinRoot, string vehicleRoot, VehicleAction action)
+        {
+            if (Sound.TryResolveCustom(value, builtinRoot, vehicleRoot, action, out var resolved, out var error, out _))
+                return resolved!;
+
+            var fallback = Sound.ResolveOfficialFallback(builtinRoot, "Vehicle1", action);
+            if (!string.IsNullOrWhiteSpace(fallback))
+                return fallback!;
+
+            // No custom file and no official fallback (a broken installation, not just a mispackaged car):
+            // surface the original problem rather than silently continuing.
+            throw new InvalidDataException(error);
+        }
+
+        private static void SetOptional(VehicleDefinition def, VehicleAction action, string value, string builtinRoot, string vehicleRoot)
+        {
+            // Optional slots simply drop out when unresolvable; the engine treats them as absent.
+            if (Sound.TryResolveCustom(value, builtinRoot, vehicleRoot, action, out var resolved, out _, out _))
+                def.SetSoundPath(action, resolved!);
+        }
+
+        private static string[] ResolveRequiredList(IReadOnlyList<string> values, string builtinRoot, string vehicleRoot, VehicleAction action)
+        {
+            var resolved = ResolveOptionalList(values, builtinRoot, vehicleRoot, action);
+            if (resolved.Length > 0)
+                return resolved;
+
+            var fallback = Sound.ResolveOfficialFallback(builtinRoot, "Vehicle1", action);
+            if (!string.IsNullOrWhiteSpace(fallback))
+                return new[] { fallback! };
+
+            throw new InvalidDataException($"No valid sound paths resolved for {action}, and no official fallback is available.");
+        }
+
+        private static string[] ResolveOptionalList(IReadOnlyList<string> values, string builtinRoot, string vehicleRoot, VehicleAction action)
+        {
+            if (values == null || values.Count == 0)
+                return Array.Empty<string>();
+
+            var result = new List<string>(values.Count);
+            for (var i = 0; i < values.Count; i++)
+                if (Sound.TryResolveCustom(values[i], builtinRoot, vehicleRoot, action, out var resolved, out _, out _))
+                    result.Add(resolved!);
+
+            return result.ToArray();
         }
     }
 }

--- a/top_speed_net/TopSpeed/Vehicles/loader/Sound.cs
+++ b/top_speed_net/TopSpeed/Vehicles/loader/Sound.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using TopSpeed.Data;
 using TopSpeed.Protocol;
+using TopSpeed.Vehicles.Parsing;
 
 namespace TopSpeed.Vehicles.Loader
 {
@@ -54,20 +55,61 @@ namespace TopSpeed.Vehicles.Loader
             string vehicleRoot,
             VehicleAction builtinAction)
         {
+            if (!TryResolveCustom(value, builtinRoot, vehicleRoot, builtinAction, out var resolved, out var error, out var missingFile))
+            {
+                if (missingFile != null)
+                    throw new FileNotFoundException(error, missingFile);
+                throw new InvalidDataException(error);
+            }
+
+            return resolved!;
+        }
+
+        /// <summary>
+        /// Non-throwing counterpart to <see cref="ResolveCustom"/>. Returns false with a human-readable
+        /// <paramref name="error"/> instead of throwing so callers (the custom-vehicles menu, the race
+        /// loader's graceful fallback) can surface problems through the warning system rather than crashing.
+        /// When the failure is specifically a missing file on disk, <paramref name="missingFile"/> holds the
+        /// resolved path; when it is a malformed/unsafe reference, <paramref name="missingFile"/> is null.
+        /// </summary>
+        public static bool TryResolveCustom(
+            string value,
+            string builtinRoot,
+            string vehicleRoot,
+            VehicleAction builtinAction,
+            out string? resolved,
+            out string? error,
+            out string? missingFile)
+        {
+            resolved = null;
+            error = null;
+            missingFile = null;
+
             if (string.IsNullOrWhiteSpace(value))
-                throw new InvalidDataException($"Missing required sound value for {builtinAction}.");
+            {
+                error = $"Missing required sound value for {builtinAction}.";
+                return false;
+            }
 
             var trimmed = value.Trim();
             if (trimmed.StartsWith(BuiltinPrefix, StringComparison.OrdinalIgnoreCase))
             {
                 var fromBuiltin = ResolveCustomBuiltin(trimmed, builtinRoot, builtinAction);
                 if (!string.IsNullOrWhiteSpace(fromBuiltin))
-                    return fromBuiltin!;
-                throw new InvalidDataException($"Builtin sound reference '{trimmed}' for {builtinAction} could not be resolved.");
+                {
+                    resolved = fromBuiltin!;
+                    return true;
+                }
+
+                error = $"Builtin sound reference '{trimmed}' for {builtinAction} could not be resolved.";
+                return false;
             }
 
             if (Path.IsPathRooted(trimmed))
-                throw new InvalidDataException($"Absolute sound paths are not allowed for custom vehicles: {trimmed}");
+            {
+                error = $"Absolute sound paths are not allowed for custom vehicles: {trimmed}";
+                return false;
+            }
 
             var normalized = trimmed
                 .Replace('/', Path.DirectorySeparatorChar)
@@ -75,15 +117,129 @@ namespace TopSpeed.Vehicles.Loader
                 .TrimStart(Path.DirectorySeparatorChar);
 
             if (normalized.IndexOf(':') >= 0 || ContainsTraversal(normalized))
-                throw new InvalidDataException($"Invalid custom sound path '{trimmed}'. Paths must stay inside the vehicle folder.");
+            {
+                error = $"Invalid custom sound path '{trimmed}'. Paths must stay inside the vehicle folder.";
+                return false;
+            }
 
             var rootFull = Path.GetFullPath(vehicleRoot);
             var candidate = Path.GetFullPath(Path.Combine(rootFull, normalized));
             if (!IsInsideRoot(rootFull, candidate))
-                throw new InvalidDataException($"Custom sound path '{trimmed}' escapes the vehicle folder.");
+            {
+                error = $"Custom sound path '{trimmed}' escapes the vehicle folder.";
+                return false;
+            }
+
             if (!File.Exists(candidate))
-                throw new FileNotFoundException($"Custom vehicle sound file not found: {candidate}", candidate);
-            return candidate;
+            {
+                missingFile = candidate;
+                error = $"Custom vehicle sound file not found: {candidate}";
+                return false;
+            }
+
+            resolved = candidate;
+            return true;
+        }
+
+        /// <summary>
+        /// One problem found while validating a custom vehicle's declared sounds. <see cref="Required"/>
+        /// distinguishes a slot the car cannot run without (engine, start, horn, brake, at least one crash)
+        /// from an optional one (stop, throttle, backfire) that can simply be skipped.
+        /// </summary>
+        public readonly struct SoundIssue
+        {
+            public SoundIssue(VehicleAction action, bool required, string message, string? missingPath = null)
+            {
+                Action = action;
+                Required = required;
+                Message = message;
+                MissingPath = missingPath;
+            }
+
+            public VehicleAction Action { get; }
+            public bool Required { get; }
+            public string Message { get; }
+
+            // Set when the failure is specifically a missing file on disk; null for malformed/unsafe
+            // references. Lets the menu render "sound file not found: <path>" without re-deriving it.
+            public string? MissingPath { get; }
+        }
+
+        /// <summary>
+        /// Walks every declared sound reference for a parsed custom vehicle and reports the ones that do not
+        /// resolve (missing files, unsafe paths, unresolvable builtins). Does not throw and does not stop at
+        /// the first problem, so the caller can show a complete picture. Builtin references and absent optional
+        /// slots that are legitimately empty produce no issue.
+        /// </summary>
+        public static IReadOnlyList<SoundIssue> ValidateCustomSounds(
+            CustomVehicleSounds sounds,
+            string builtinRoot,
+            string vehicleRoot)
+        {
+            var issues = new List<SoundIssue>();
+
+            CheckRequired(issues, sounds.Engine, builtinRoot, vehicleRoot, VehicleAction.Engine);
+            CheckRequired(issues, sounds.Start, builtinRoot, vehicleRoot, VehicleAction.Start);
+            CheckRequired(issues, sounds.Horn, builtinRoot, vehicleRoot, VehicleAction.Horn);
+            CheckRequired(issues, sounds.Brake, builtinRoot, vehicleRoot, VehicleAction.Brake);
+            CheckRequiredList(issues, sounds.CrashVariants, builtinRoot, vehicleRoot, VehicleAction.Crash);
+
+            CheckOptional(issues, sounds.Stop, builtinRoot, vehicleRoot, VehicleAction.Stop);
+            CheckOptional(issues, sounds.Throttle, builtinRoot, vehicleRoot, VehicleAction.Throttle);
+            CheckOptionalList(issues, sounds.BackfireVariants, builtinRoot, vehicleRoot, VehicleAction.Backfire);
+
+            return issues;
+        }
+
+        private static void CheckRequired(
+            List<SoundIssue> issues, string value, string builtinRoot, string vehicleRoot, VehicleAction action)
+        {
+            if (!TryResolveCustom(value, builtinRoot, vehicleRoot, action, out _, out var error, out var missing))
+                issues.Add(new SoundIssue(action, true, error!, missing));
+        }
+
+        private static void CheckOptional(
+            List<SoundIssue> issues, string? value, string builtinRoot, string vehicleRoot, VehicleAction action)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return;
+            if (!TryResolveCustom(value!, builtinRoot, vehicleRoot, action, out _, out var error, out var missing))
+                issues.Add(new SoundIssue(action, false, error!, missing));
+        }
+
+        private static void CheckRequiredList(
+            List<SoundIssue> issues, IReadOnlyList<string> values, string builtinRoot, string vehicleRoot, VehicleAction action)
+        {
+            if (values == null || values.Count == 0)
+            {
+                issues.Add(new SoundIssue(action, true, $"Missing required sound value for {action}."));
+                return;
+            }
+
+            var anyValid = false;
+            for (var i = 0; i < values.Count; i++)
+            {
+                if (TryResolveCustom(values[i], builtinRoot, vehicleRoot, action, out _, out var error, out var missing))
+                    anyValid = true;
+                else
+                    issues.Add(new SoundIssue(action, !anyValid, error!, missing));
+            }
+
+            // A single surviving variant is enough to run; only escalate to required if none resolved.
+            if (anyValid)
+                for (var i = 0; i < issues.Count; i++)
+                    if (issues[i].Action == action && issues[i].Required)
+                        issues[i] = new SoundIssue(action, false, issues[i].Message, issues[i].MissingPath);
+        }
+
+        private static void CheckOptionalList(
+            List<SoundIssue> issues, IReadOnlyList<string> values, string builtinRoot, string vehicleRoot, VehicleAction action)
+        {
+            if (values == null || values.Count == 0)
+                return;
+            for (var i = 0; i < values.Count; i++)
+                if (!TryResolveCustom(values[i], builtinRoot, vehicleRoot, action, out _, out var error, out var missing))
+                    issues.Add(new SoundIssue(action, false, error!, missing));
         }
 
         private static string GetDefaultFileName(VehicleAction action)


### PR DESCRIPTION
## Problem

A custom vehicle whose `.tsv` referenced a **required** sound file that wasn't on disk (e.g. a `.tsv` that shipped without its `.wav`) threw a `FileNotFoundException` deep in the race loader (`Sound.ResolveCustom`), taking down startup. This came from a real user report — a custom car whose engine sound file was missing from the vehicle folder.

## Fix — catch it at two layers

**Custom-vehicles menu (primary).** `Sound.ValidateCustomSounds` walks every declared sound reference when the menu is opened — cheap `File.Exists` on custom refs only (builtin tokens skipped), gated behind the existing per-file parse cache. Every missing sound is reported as a **Warning** through the existing warning panel, and the car stays selectable and playable. The line states which kind of sound it is:
- **required sound** (a built-in default will be used) — engine/start/horn/brake/at least one crash
- **optional sound** (it will be skipped) — stop/throttle/backfire

followed by the missing path.

**Race loader (makes that safe).** `Custom.Load` substitutes the official builtin sound for a missing required slot (and skips missing optional slots) rather than throwing, so a selected car — whether chosen from the menu or reached another way (e.g. a persisted last-selection) — races with default sounds instead of crashing.

`ResolveCustom` is refactored onto a non-throwing `TryResolveCustom` core so the menu check and the loader fallback share one path-safety implementation (traversal/absolute-path/escape rules can't drift apart).

## Notes / scope

- **Client-only.** The server references only `TopSpeed.Shared`; the parser, `Sound.cs`, and `Custom.cs` all live in the client `TopSpeed` project, so the server is unaffected. No protocol/version change.
- No line number is attached to the missing-sound message: consistent with the codebase, where line-cited issues are for malformed *values* the parser evaluates, not asset existence (the `.tsm` parser doesn't existence-check sounds either, and can't — it's shared with the server).

## Tests

New `CustomSoundValidationBehaviorTests` (6 cases) pins the required/optional classification (which now drives the warning wording): all-present → no issues; missing required engine → required + missing-path reported; missing optional stop → optional; crash list with one surviving variant → not required; empty crash list → required; builtin-only refs → not flagged. Existing vehicle tests still pass.

---

It might be worth a follow-up to add the same missing-sound warnings to the `.tsm` track parser, which currently skips a missing referenced sound silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
