### PR TITLE
Fix cars wrecking at start/finish and pit exit (lap-boundary road jump)

### DIFF
--- a/docs/en/changes.md
+++ b/docs/en/changes.md
@@ -5,6 +5,14 @@ This file tracks new changes to the game for both client and server to make it e
 The game versioning follows a specific pattern by using year.month.day.revision, where revision is an incremental number if there is more than one release in a single day.
 
 
+## 2026.7.23.1
+### Game Changes
+- Fixed a bug that could wreck your car for no reason as you crossed the start/finish line or pulled out of the pit lane, most often during longer races. For a single frame the road shifted a full track-width sideways and the game counted you as off the track.
+
+### Server Changes
+- Fixed the same start/finish line glitch for the computer-controlled cars, which could spin them out for no reason as they completed a lap.
+
+
 ## 2026.7.17.1
 ### Game Changes
 - Fixed a crash that could happen when starting a race with a custom vehicle that was missing one of its sound files. The vehicle now stays playable: any missing sound is replaced with a built-in default (or, for optional sounds, simply left silent), and the custom vehicles menu shows a warning describing what was missing.

--- a/info.json
+++ b/info.json
@@ -1,12 +1,14 @@
 {
-  "version": "2026.7.17.1",
-  "serverVersion": "2026.7.15.1",
+  "version": "2026.7.23.1",
+  "serverVersion": "2026.7.23.1",
   "changes": [
+    "Fixed a bug that could wreck your car for no reason as you crossed the start/finish line or pulled out of the pit lane, most often during longer races. For a single frame the road shifted a full track-width sideways and the game counted you as off the track.",
     "Fixed a crash that could happen when starting a race with a custom vehicle that was missing one of its sound files. The vehicle now stays playable: any missing sound is replaced with a built-in default (or, for optional sounds, simply left silent), and the custom vehicles menu shows a warning describing what was missing.",
     "Fixed a single race bug where the computer cars could still bump into you after you had already finished the race, such as while waiting on the finish line with your engine running. Being hit could leave your car sliding out of your control and could delay the end of the race.",
     "Removed some unused sound files that were bundled with the non-English language packs."
   ],
   "serverChanges": [
+    "Fixed the same start/finish line glitch for the computer-controlled cars, which could spin them out for no reason as they completed a lap.",
     "Raised the minimum supported network protocol to the 500-lap update. Game clients older than that update are now rejected when they connect, instead of mis-reading race data. Clients and servers must both be on the 500-lap update or newer to play together."
   ]
 }

--- a/top_speed_net/TopSpeed.Shared/Data/Tracks/RoadModel.cs
+++ b/top_speed_net/TopSpeed.Shared/Data/Tracks/RoadModel.cs
@@ -74,8 +74,23 @@ namespace TopSpeed.Data
             if (_defs.Length == 0 || LapDistance <= 0f)
                 return new RoadSeg(0f, 0f, TrackSurface.Asphalt, TrackType.Straight, MinPartLengthMeters, -1, 0f);
 
+            // Derive the in-lap distance from the same lap index instead of an
+            // independent modulo, so the two can never disagree at a lap
+            // boundary (a float-rounding split there used to shift the road one
+            // LapCenter sideways for a frame and crash the car — most reliably
+            // on pit exit, which lands exactly on the boundary).
             var lap = (int)Math.Floor(position / LapDistance);
-            var pos = Wrap(position);
+            var pos = position - (lap * LapDistance);
+            if (pos >= LapDistance)
+            {
+                pos -= LapDistance;
+                lap++;
+            }
+            else if (pos < 0f)
+            {
+                pos += LapDistance;
+                lap--;
+            }
             var dist = 0.0f;
             var center = lap * LapCenter;
 

--- a/top_speed_net/TopSpeed.Shared/Protocol/VersionInfo.cs
+++ b/top_speed_net/TopSpeed.Shared/Protocol/VersionInfo.cs
@@ -6,13 +6,13 @@ namespace TopSpeed.Protocol
         // Client release version used by updater checks and release packaging.
         public const ushort ClientYear = 2026;
         public const byte ClientMonth = 7;
-        public const byte ClientDay = 17;
+        public const byte ClientDay = 23;
         public const byte ClientRevision = 1;
 
         // Server release version used by updater checks and packaging.
         public const ushort ServerYear = 2026;
         public const byte ServerMonth = 7;
-        public const byte ServerDay = 15;
+        public const byte ServerDay = 23;
         public const byte ServerRevision = 1;
     }
 
@@ -25,7 +25,7 @@ namespace TopSpeed.Protocol
         // Current protocol implementation version (year.month.day.revision).
         public const ushort CurrentYear = 2026;
         public const byte CurrentMonth = 7;
-        public const byte CurrentDay = 13;
+        public const byte CurrentDay = 23;
         public const byte CurrentRevision = 1;
 
         // Client supported protocol range (explicit values by design).
@@ -35,7 +35,7 @@ namespace TopSpeed.Protocol
         public const byte ClientMinRevision = 1;
         public const ushort ClientMaxYear = 2026;
         public const byte ClientMaxMonth = 7;
-        public const byte ClientMaxDay = 13;
+        public const byte ClientMaxDay = 23;
         public const byte ClientMaxRevision = 1;
 
         // Server supported protocol range (explicit values by design).
@@ -45,7 +45,7 @@ namespace TopSpeed.Protocol
         public const byte ServerMinRevision = 1;
         public const ushort ServerMaxYear = 2026;
         public const byte ServerMaxMonth = 7;
-        public const byte ServerMaxDay = 13;
+        public const byte ServerMaxDay = 23;
         public const byte ServerMaxRevision = 1;
     }
 }

--- a/top_speed_net/TopSpeed.Tests/Behavior/Shared/Tracks/RoadModelLapBoundaryBehavior.cs
+++ b/top_speed_net/TopSpeed.Tests/Behavior/Shared/Tracks/RoadModelLapBoundaryBehavior.cs
@@ -1,0 +1,114 @@
+using System;
+using TopSpeed.Data;
+using Xunit;
+
+namespace TopSpeed.Tests;
+
+// Regression coverage for the lap-boundary road jump that crashed cars at the
+// start/finish line and on pit exit. RoadModel.At() used to derive the lap index
+// (floor(position / LapDistance)) and the in-lap distance (position % LapDistance)
+// from two independent calculations. At a lap boundary float rounding could split
+// them — one saying "end of lap N", the other "start of lap N+1" — and because each
+// lap is offset sideways by LapCenter, that one-frame disagreement shifted the road a
+// whole LapCenter and threw the car out of bounds.
+//
+// The track under test is a representative oval: nine segments with four left curves,
+// so LapCenter is a large non-zero -134 m. Any track with a non-zero LapCenter is
+// vulnerable; if the lap index and the in-lap distance ever disagree, the road center
+// jumps by that full amount, which these tests catch.
+[Trait("Category", "Behavior")]
+public sealed class RoadModelLapBoundaryBehaviorTests
+{
+    private static TrackDefinition Seg(TrackType type, float length) =>
+        new TrackDefinition(type, TrackSurface.Asphalt, TrackNoise.NoNoise, length);
+
+    private static TrackDefinition[] CurvedOvalDefinitions() => new[]
+    {
+        Seg(TrackType.Straight, 502.92f),
+        Seg(TrackType.HardLeft, 402f),
+        Seg(TrackType.Straight, 201f),
+        Seg(TrackType.Left, 402f),
+        Seg(TrackType.Straight, 1006f),
+        Seg(TrackType.HardLeft, 402f),
+        Seg(TrackType.Straight, 203f),
+        Seg(TrackType.Left, 402f),
+        Seg(TrackType.Straight, 502.92f),
+    };
+
+    private static float Center(RoadSeg seg) => (seg.Left + seg.Right) * 0.5f;
+
+    [Fact]
+    public void Geometry_HasExpectedLapDistanceAndCenter()
+    {
+        var model = new RoadModel(CurvedOvalDefinitions());
+
+        // Documents the geometry the rest of the tests rely on.
+        model.LapDistance.Should().BeApproximately(4023.84f, 0.01f);
+        model.LapCenter.Should().BeApproximately(-134f, 0.01f);
+    }
+
+    [Fact]
+    public void At_ExactLapBoundaries_StaysOnTheCorrectLap()
+    {
+        var model = new RoadModel(CurvedOvalDefinitions());
+
+        // Each lap starts on segment 1 (a straight), whose center is exactly the lap's
+        // sideways offset lap * LapCenter. If the index/distance split fires, the center
+        // lands a whole LapCenter (134 m) away — far outside this tolerance.
+        for (var lap = 1; lap <= 500; lap++)
+        {
+            var position = lap * model.LapDistance;
+            var center = Center(model.At(position));
+
+            center.Should().BeApproximately(lap * model.LapCenter, 1.0f,
+                $"the road center at the start of lap {lap} (position {position}) must not jump a LapCenter");
+        }
+    }
+
+    [Fact]
+    public void At_IsContinuousAcrossLapBoundaries()
+    {
+        var model = new RoadModel(CurvedOvalDefinitions());
+
+        // Step finely across each seam; the center must never move more than the car
+        // could physically travel between samples. A split shows up as a ~134 m jump.
+        for (var lap = 1; lap <= 500; lap++)
+        {
+            var boundary = lap * model.LapDistance;
+            var before = Center(model.At(MathF.BitDecrement(boundary)));
+            var at = Center(model.At(boundary));
+            var after = Center(model.At(boundary + 0.1f));
+
+            Math.Abs(at - before).Should().BeLessThan(2.0f,
+                $"road center must not jump across the lap {lap} seam");
+            Math.Abs(after - at).Should().BeLessThan(2.0f,
+                $"road center must not jump just after the lap {lap} seam");
+        }
+    }
+
+    [Fact]
+    public void At_PitExitReconstruction_MatchesNeighbouringRoad()
+    {
+        var model = new RoadModel(CurvedOvalDefinitions());
+        var lapDist = model.LapDistance;
+
+        // Pit exit rejoins at floor(entry / lapDist) * lapDist + exitDistanceInLap — an
+        // exact lap multiple plus an offset, which is what used to land dead on the
+        // ambiguous boundary. Rebuild that position for many laps and a range of exit
+        // offsets and confirm the road there agrees with the road a hair earlier/later.
+        float[] exitOffsets = { 0f, 0.5f, 50f, 201f, 402f };
+        for (var lap = 0; lap < 500; lap++)
+        {
+            var lapStart = (float)Math.Floor((lap * lapDist + 10f) / lapDist) * lapDist;
+            foreach (var exitOffset in exitOffsets)
+            {
+                var exitY = lapStart + exitOffset;
+                var here = Center(model.At(exitY));
+                var justAfter = Center(model.At(exitY + 0.1f));
+
+                Math.Abs(justAfter - here).Should().BeLessThan(2.0f,
+                    $"pit-exit road center at lap {lap}, offset {exitOffset} must not jump a LapCenter");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

Fixes cars wrecking for no reason at the start/finish line and on pit exit — a one-frame lap-boundary road jump.

`RoadModel.At()` derived the lap index (`floor(position / LapDistance)`) and the in-lap distance (a separate modulo) from two independent calculations. At a lap boundary float rounding could split them — one saying "end of lap N", the other "start of lap N+1" — and because each lap is offset sideways by `LapCenter`, that one-frame disagreement shifted the road a full track-width and threw the car out of bounds. Deriving the in-lap distance from the same lap index keeps the two consistent, so the road stays continuous across the seam. Behavior is unchanged everywhere except the boundary.

Both the client (the player off-road check) and the server (bot driving) run the same check off `At()`, so this fixes it for players and computer cars alike.

## Sidenote on history

This fix was written before pit stops and the 500-lap update went to main, and it rode along through numerous try builds that got hours of playtesting confirming it worked. When all of that landed on main, though, this one commit didn't make it in — so the shipped builds still had the bug. Here it is now.

## Commits (please merge without squash)

1. **Fix lap-boundary road jump that crashed cars at start/finish and pit exit** — the one-line consistency fix in `RoadModel.At()`.
2. **Add regression tests for the lap-boundary road jump** — assert `At()` stays continuous across lap seams on a representative curved oval; fail on the pre-fix code with a ~134 m road jump at a lap seam, pass with the fix.
3. **Bump version to 2026.7.23.1** — client and server release versions; the fix changes bot behavior but not the wire format, so the current + max supported protocol advance to match while the minimum stays at 2026.7.13.1 (older peers still connect). Changelog prepended to `info.json` and `docs/en/changes.md`.
