### PR TITLE
Make the locale template source comments stable

### DIFF
--- a/top_speed_net/languages/Generate-Templates.ps1
+++ b/top_speed_net/languages/Generate-Templates.ps1
@@ -15,6 +15,23 @@ function Resolve-ExecutablePath {
     return $command.Source
 }
 
+function ConvertTo-RepositoryRelativePath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+        [Parameter(Mandatory = $true)]
+        [string]$RepositoryRoot
+    )
+
+    $normalizedRoot = [System.IO.Path]::GetFullPath($RepositoryRoot).TrimEnd([char]'\', [char]'/')
+    $normalizedPath = [System.IO.Path]::GetFullPath($Path)
+    if (-not $normalizedPath.StartsWith($normalizedRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Source file '$Path' is outside the repository root '$RepositoryRoot'."
+    }
+
+    return $normalizedPath.Substring($normalizedRoot.Length).TrimStart([char]'\', [char]'/').Replace('\', '/')
+}
+
 function Get-CSharpSourceFiles {
     param(
         [Parameter(Mandatory = $true)]
@@ -55,13 +72,21 @@ function Invoke-TemplateGeneration {
         [Parameter(Mandatory = $true)]
         [string[]]$KeywordArguments,
         [Parameter(Mandatory = $true)]
-        [string]$XGetTextPath
+        [string]$XGetTextPath,
+        [Parameter(Mandatory = $true)]
+        [string]$RepositoryRoot
     )
 
     $sourceFiles = Get-CSharpSourceFiles -SourceDirectories $SourceDirectories
     if ($sourceFiles.Count -eq 0) {
         throw "No C# source files were found for scope '$ScopeName'."
     }
+
+    # xgettext copies each input path verbatim into the "#:" source comments, so absolute paths
+    # would bake the generating machine's checkout location into the template and every developer
+    # would rewrite all of them. Pass repository-relative, forward-slashed paths (resolved against
+    # --directory) so the templates are identical regardless of who runs this, or on which platform.
+    $sourceFiles = @($sourceFiles | ForEach-Object { ConvertTo-RepositoryRelativePath -Path $_ -RepositoryRoot $RepositoryRoot } | Sort-Object -Unique)
 
     $templateDirectory = Split-Path -Parent $TemplatePath
     if (-not (Test-Path -LiteralPath $templateDirectory)) {
@@ -76,6 +101,7 @@ function Invoke-TemplateGeneration {
             "--from-code=UTF-8",
             "--language=C#",
             "--sort-output",
+            "--directory", $RepositoryRoot,
             "--output", $TemplatePath,
             "--files-from", $temporaryFileList
         ) + $KeywordArguments
@@ -93,6 +119,7 @@ function Invoke-TemplateGeneration {
 }
 
 $solutionRoot = Split-Path -Parent $PSScriptRoot
+$repositoryRoot = Split-Path -Parent $solutionRoot
 $clientTemplatePath = Join-Path $PSScriptRoot "client/messages.pot"
 $serverTemplatePath = Join-Path $PSScriptRoot "server/messages.pot"
 
@@ -114,7 +141,8 @@ Invoke-TemplateGeneration `
         (Join-Path $solutionRoot "TopSpeed.Shared")
     ) `
     -KeywordArguments $sharedKeywordArguments `
-    -XGetTextPath $xgettextPath
+    -XGetTextPath $xgettextPath `
+    -RepositoryRoot $repositoryRoot
 
 Invoke-TemplateGeneration `
     -ScopeName "server" `
@@ -124,4 +152,5 @@ Invoke-TemplateGeneration `
         (Join-Path $solutionRoot "TopSpeed.Shared")
     ) `
     -KeywordArguments $sharedKeywordArguments `
-    -XGetTextPath $xgettextPath
+    -XGetTextPath $xgettextPath `
+    -RepositoryRoot $repositoryRoot

--- a/top_speed_net/languages/Generate-Templates.ps1
+++ b/top_speed_net/languages/Generate-Templates.ps1
@@ -86,6 +86,10 @@ function Invoke-TemplateGeneration {
     # would bake the generating machine's checkout location into the template and every developer
     # would rewrite all of them. Pass repository-relative, forward-slashed paths (resolved against
     # --directory) so the templates are identical regardless of who runs this, or on which platform.
+    # The comments are also emitted without line numbers (--add-location=file below): line numbers
+    # shift whenever surrounding code moves, which rewrote thousands of comment lines on every
+    # regeneration without a single translatable string having changed. The file name still tells a
+    # translator where a string lives, and now only changes if the string moves to another file.
     $sourceFiles = @($sourceFiles | ForEach-Object { ConvertTo-RepositoryRelativePath -Path $_ -RepositoryRoot $RepositoryRoot } | Sort-Object -Unique)
 
     $templateDirectory = Split-Path -Parent $TemplatePath
@@ -101,6 +105,7 @@ function Invoke-TemplateGeneration {
             "--from-code=UTF-8",
             "--language=C#",
             "--sort-output",
+            "--add-location=file",
             "--directory", $RepositoryRoot,
             "--output", $TemplatePath,
             "--files-from", $temporaryFileList

--- a/top_speed_net/languages/client/messages.pot
+++ b/top_speed_net/languages/client/messages.pot
@@ -8,1552 +8,1553 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-27 18:44+0300\n"
+"POT-Creation-Date: 2026-07-27 22:42-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:122
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "2 degrees"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:123
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "3 degrees"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:124
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "4 degrees"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:125
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "5 degrees"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:108
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "A cleaner lap would have been a much better choice."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Check.cs:178
+#: top_speed_net/TopSpeed/Game/Updates/Check.cs
 #, csharp-format
 msgid ""
 "A new version of Top Speed was detected. Your current version is {0}. The "
 "new version is {1}. Would you like to download the update?"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Settings\Manager\Apply\Network.cs:42
+#: top_speed_net/TopSpeed/Core/Settings/Manager/Apply/Network.cs
 msgid "A saved server entry was ignored because the host is empty."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\TrackPackages\UploadRuntime.cs:58
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/TrackPackages/UploadRuntime.cs
 msgid "A track upload is already in progress."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Menu\About.cs:24
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Core.cs:154
+#: top_speed_net/TopSpeed/Game/Menu/About.cs
+#: top_speed_net/TopSpeed/Menu/Build/Core.cs
 msgid "About"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Audio.cs:20
+#: top_speed_net/TopSpeed/Menu/Build/Options/Audio.cs
 msgid ""
 "Accessibility option for clearer left-right cues with HRTF. It attenuates "
 "the opposite ear for your own car sounds only."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Drive\Map\Actions.cs:19
+#: top_speed_net/TopSpeed/Input/Drive/Map/Actions.cs
 msgid "Action"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Items\MenuItem.cs:123
+#: top_speed_net/TopSpeed/Menu/Items/MenuItem.cs
 msgid "Actions available."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:42
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Add"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Menu\LobbyAndControls.cs:39
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Menu/LobbyAndControls.cs
 msgid "Add a bot"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\SavedServers\Menu.cs:34
+#: top_speed_net/TopSpeed/Core/Multiplayer/SavedServers/Menu.cs
 msgid "Add a new server"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Main.cs:30
+#: top_speed_net/TopSpeed/Menu/Build/Options/Main.cs
 msgid ""
 "Adjust category-based volume balance for engine sounds, effects, ambience, "
 "radio, music, and online events."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Speech.cs:143
+#: top_speed_net/TopSpeed/Menu/Build/Options/Speech.cs
 msgid "Adjust the speech rate for the current backend."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:309
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "All menu shortcuts were reset to defaults."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Protocol\RoomTexts.cs:7
+#: top_speed_net/TopSpeed.Shared/Protocol/RoomTexts.cs
 msgid "All players are ready. Starting game."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\ModifierKeys.cs:116
+#: top_speed_net/TopSpeed/Input/ModifierKeys.cs
 msgid "Alt"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\VolumeShortcuts.cs:242
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Volume.cs:50
+#: top_speed_net/TopSpeed/Game/Settings/VolumeShortcuts.cs
+#: top_speed_net/TopSpeed/Menu/Build/Options/Volume.cs
 msgid "Ambients and sound sources"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\TrackList.cs:25
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:96
+#: top_speed_net/TopSpeed/Core/TrackList.cs
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
 msgid "America"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Audio.cs:37
+#: top_speed_net/TopSpeed/Menu/Build/Options/Audio.cs
 msgid ""
 "Amplifies the captured microphone signal before it is sent to other players. "
 "100 is unity gain. Raise this if other players report you sound too quiet; "
 "lower it if your voice clips."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Program.cs:142
-#: D:\top_speed\top_speed_net\TopSpeed\Program.cs:156
+#: top_speed_net/TopSpeed/Program.cs
 #, csharp-format
 msgid "An unexpected error occurred. A log file was created: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Check.cs:34
+#: top_speed_net/TopSpeed/Game/Updates/Check.cs
 msgid "An update download is already in progress."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Install.cs:101
+#: top_speed_net/TopSpeed/Game/Updates/Install.cs
 msgid "Android package installer is not available."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Install.cs:86
+#: top_speed_net/TopSpeed/Game/Updates/Install.cs
 msgid "Android updates require an APK package."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:169
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Announce frequency"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:28
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Apostrophe"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:79
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Applications"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Session.cs:24
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Session.cs
 msgid "Are you sure you want to disconnect?"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\Room.cs:28
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/Room.cs
 msgid "Are you sure you want to leave the current room?"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Race\Runtime.cs:257
+#: top_speed_net/TopSpeed/Game/Multiplayer/Race/Runtime.cs
 msgid "Are you sure you want to quit this multiplayer race?"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\SavedServers\Form.cs:64
+#: top_speed_net/TopSpeed/Core/Multiplayer/SavedServers/Form.cs
 msgid "Are you sure you would like to discard all changes?"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Input.cs:75
+#: top_speed_net/TopSpeed/Game/Settings/Input.cs
 msgid ""
 "Are you sure you would like to restore all controller bindings to their "
 "default values?"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Input.cs:74
+#: top_speed_net/TopSpeed/Game/Settings/Input.cs
 msgid ""
 "Are you sure you would like to restore all keyboard bindings to their "
 "default values?"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Input.cs:51
+#: top_speed_net/TopSpeed/Game/Settings/Input.cs
 msgid ""
 "Are you sure you would like to restore all settings to their default values?"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:46
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "At"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:91
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "At least it only happened once."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:137
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "At that point you were collecting crashes, not corners."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:144
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "At that point, everyone could hear the mistakes."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:123
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "At this rate the crash sound is becoming your theme music."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Connection\Connect.cs:110
+#: top_speed_net/TopSpeed/Core/Multiplayer/Connection/Connect.cs
 msgid "Attempting to connect, please wait..."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Main.cs:20
+#: top_speed_net/TopSpeed/Menu/Build/Options/Main.cs
 msgid "Audio"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\TrackList.cs:26
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:98
+#: top_speed_net/TopSpeed/Core/TrackList.cs
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
 msgid "Austria"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:91
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:101
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:111
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Auto"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:97
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:107
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:117
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Auto detects wheel pedal direction from resting position."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Audio.cs:31
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Audio.cs:40
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Drive\Transmission.cs:30
+#: top_speed_net/TopSpeed/Game/Settings/Audio.cs
+#: top_speed_net/TopSpeed/Menu/Build/Drive/Transmission.cs
 msgid "Automatic"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Audio.cs:21
+#: top_speed_net/TopSpeed/Menu/Build/Options/Audio.cs
 msgid "Automatic audio device format"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Drive.cs:42
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
 msgid "Automatic race information"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Create.cs:92
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Create.cs
 msgid "Automatic room name selected."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Menu\Loadout.cs:29
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Menu/Loadout.cs
 msgid "Automatic transmission"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Drive\Vehicles.cs:64
+#: top_speed_net/TopSpeed/Menu/Build/Drive/Vehicles.cs
 msgid "Automatic transmission is required for this vehicle."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Game.cs:48
+#: top_speed_net/TopSpeed/Menu/Build/Options/Game.cs
 msgid "Automatically focus first menu item"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Multiplayer.cs:53
+#: top_speed_net/TopSpeed/Menu/Build/Multiplayer.cs
 msgid "Available game rooms"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Multiplayer.cs:21
+#: top_speed_net/TopSpeed/Menu/Build/Multiplayer.cs
 msgid "Available servers"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:189
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 #, csharp-format
 msgid "Average lap time for this track: {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:166
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 #, csharp-format
 msgid "Average time for this track over {0} laps: {1}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:165
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 #, csharp-format
 msgid "Average {0}-lap time for this track: {1}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\TrackPackages\UploadProgress.cs:50
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Dialog.cs:63
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/TrackPackages/UploadProgress.cs
+#: top_speed_net/TopSpeed/Game/Updates/Dialog.cs
 msgid "B"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Vehicles\Catalog\Data.cs:272
+#: top_speed_net/TopSpeed.Shared/Vehicles/Catalog/Data.cs
 msgid "BMW 3 Series"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:32
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Backslash"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:21
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Backspace"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\TrackList.cs:27
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:100
+#: top_speed_net/TopSpeed/Core/TrackList.cs
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
 msgid "Belgium"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:183
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 #, csharp-format
 msgid "Best lap for this track: {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:177
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 #, csharp-format
 msgid "Best lap this run: {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:160
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 #, csharp-format
 msgid "Best recorded run: {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:159
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 #, csharp-format
 msgid "Best time so far: {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Settings\Manager\Apply\Input.cs:114
+#: top_speed_net/TopSpeed/Core/Settings/Manager/Apply/Input.cs
 msgid "Binding intent is missing and was ignored."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Pit\PitStopMenu.cs:20
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:74
+#: top_speed_net/TopSpeed/Game/Drive/Pit/PitStopMenu.cs
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Both"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:65
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Both Alt keys"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:53
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Both Control keys"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:31
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Both Shift keys"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\Room.cs:167
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\Room.cs:185
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/Room.cs
 msgid "Bots can only be managed by the host in race-with-bots rooms."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Drive\Bind.cs:40
+#: top_speed_net/TopSpeed/Input/Drive/Bind.cs
 msgid "Brake"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:98
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Brake pedal direction"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\TrackList.cs:28
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:102
+#: top_speed_net/TopSpeed/Core/TrackList.cs
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
 msgid "Brazil"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:37
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
+msgid "Brief status reports"
+msgstr ""
+
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "Brilliant result! You set a new best time."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:144
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Button 1"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:153
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Button 10"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:154
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Button 11"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:155
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Button 12"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:156
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Button 13"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:157
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Button 14"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:158
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Button 15"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:159
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Button 16"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:145
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Button 2"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:146
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Button 3"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:147
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Button 4"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:148
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Button 5"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:149
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Button 6"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:150
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Button 7"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:151
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Button 8"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:152
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Button 9"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Connection\Connect.cs:52
+#: top_speed_net/TopSpeed/Core/Multiplayer/Connection/Connect.cs
 msgid "Call sign cannot be empty."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\Room.cs:128
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\TrackPackages\UploadProgress.cs:39
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Setup.cs:104
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Audio.cs:60
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Language.cs:54
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Dialog.cs:27
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Mapping\Handler\Keyboard.cs:44
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:289
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:327
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Dialogs\Choice.cs:51
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/Room.cs
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/TrackPackages/UploadProgress.cs
+#: top_speed_net/TopSpeed/Game/Drive/Setup.cs
+#: top_speed_net/TopSpeed/Game/Settings/Audio.cs
+#: top_speed_net/TopSpeed/Game/Settings/Language.cs
+#: top_speed_net/TopSpeed/Game/Updates/Dialog.cs
+#: top_speed_net/TopSpeed/Input/Mapping/Handler/Keyboard.cs
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
+#: top_speed_net/TopSpeed/Menu/Dialogs/Choice.cs
 msgid "Cancel"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Menus.cs:62
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Menus.cs
 msgid "Cancel and discard changes"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\LoadoutExit.cs:23
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/LoadoutExit.cs
 msgid "Cancel current game?"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Create.cs:56
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Create.cs
 msgid "Cancel room creation"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:38
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Caps Lock"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Menu\LobbyAndControls.cs:37
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Menu/LobbyAndControls.cs
 msgid "Change game options"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Core.cs:172
+#: top_speed_net/TopSpeed/Menu/Build/Core.cs
 msgid "Change log file"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Menus.cs:35
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Menus.cs
 msgid "Change the track used during the race."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Coordinator\Chat\Input.cs:65
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Coordinator\Chat\Input.cs:94
+#: top_speed_net/TopSpeed/Core/Multiplayer/Coordinator/Chat/Input.cs
 msgid "Chat message cannot be empty."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Core.cs:153
+#: top_speed_net/TopSpeed/Menu/Build/Core.cs
 msgid "Check for updates"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Game.cs:68
+#: top_speed_net/TopSpeed/Menu/Build/Options/Game.cs
 msgid "Check for updates on startup"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:63
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Check ping"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Check.cs:42
+#: top_speed_net/TopSpeed/Game/Updates/Check.cs
 msgid "Checking for updates."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\TrackList.cs:29
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:104
+#: top_speed_net/TopSpeed/Core/TrackList.cs
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
 msgid "China"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Dialogs\Choice.cs:80
+#: top_speed_net/TopSpeed/Menu/Dialogs/Choice.cs
 msgid "Choice"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Menu\Device.cs:35
+#: top_speed_net/TopSpeed/Game/Menu/Device.cs
 msgid "Choose controller"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Drive.cs:51
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
 msgid ""
 "Choose how much automatic race information is spoken, such as lap numbers "
 "and player positions."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Race\Runtime.cs:283
+#: top_speed_net/TopSpeed/Game/Multiplayer/Race/Runtime.cs
 msgid "Choose how to proceed with the current game."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\Room.cs:124
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/Room.cs
 msgid "Choose how to start this race."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Mapping\Handler\Keyboard.cs:40
+#: top_speed_net/TopSpeed/Input/Mapping/Handler/Keyboard.cs
 msgid "Choose modifier key"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Drive.cs:71
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
 msgid "Choose the difficulty level for single races."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Game.cs:29
+#: top_speed_net/TopSpeed/Menu/Build/Options/Game.cs
 msgid "Choose the language used for menu and spoken interface text."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Language.cs:40
+#: top_speed_net/TopSpeed/Game/Settings/Language.cs
 msgid "Choose the language."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Audio.cs:63
+#: top_speed_net/TopSpeed/Game/Settings/Audio.cs
 msgid "Choose the microphone used for communicator voice chat."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Menus.cs:44
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Menus.cs
 msgid "Choose the number of laps for this room."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Create.cs:25
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Create.cs
 msgid "Choose the player capacity from 2 to 10."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Drive\Tracks.cs:20
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Multiplayer.cs:93
+#: top_speed_net/TopSpeed/Menu/Build/Drive/Tracks.cs
+#: top_speed_net/TopSpeed/Menu/Build/Multiplayer.cs
 msgid "Choose track type"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Drive.cs:25
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
 msgid "Choose what information the copilot reports during a race."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Speech.cs:107
+#: top_speed_net/TopSpeed/Menu/Build/Options/Speech.cs
 msgid ""
 "Choose whether spoken messages use speech only, braille only, or speech with "
 "braille."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Create.cs:39
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Create.cs
 msgid ""
 "Choose whether this room is a race with bots, a multiplayer race without "
 "bots, or a one-on-one game."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Speech.cs:24
+#: top_speed_net/TopSpeed/Menu/Build/Options/Speech.cs
 msgid ""
 "Choose which speech backend to prefer. Automatic lets Prism pick the best "
 "available backend."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Multiplayer.cs:123
+#: top_speed_net/TopSpeed/Menu/Build/Multiplayer.cs
 msgid "Choose your transmission mode"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Multiplayer.cs:118
+#: top_speed_net/TopSpeed/Menu/Build/Multiplayer.cs
 msgid "Choose your vehicle"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultDialogs.cs:54
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultDialogs.cs:75
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Menu\About.cs:37
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Check.cs:157
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Check.cs:208
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Runtime\Screen\Core.cs:264
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultDialogs.cs
+#: top_speed_net/TopSpeed/Game/Menu/About.cs
+#: top_speed_net/TopSpeed/Game/Updates/Check.cs
+#: top_speed_net/TopSpeed/Menu/Runtime/Screen/Core.cs
 msgid "Close"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Drive\Bind.cs:41
+#: top_speed_net/TopSpeed/Input/Drive/Bind.cs
 msgid "Clutch"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:108
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Clutch pedal direction"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:47
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Colon"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\VolumeShortcuts.cs:245
+#: top_speed_net/TopSpeed/Game/Settings/VolumeShortcuts.cs
 msgid "Communicator"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Coordinator\Communicator.cs:17
+#: top_speed_net/TopSpeed/Core/Multiplayer/Coordinator/Communicator.cs
 msgid "Communicator off"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Coordinator\Communicator.cs:16
+#: top_speed_net/TopSpeed/Core/Multiplayer/Coordinator/Communicator.cs
 msgid "Communicator on"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Volume.cs:69
+#: top_speed_net/TopSpeed/Menu/Build/Options/Volume.cs
 msgid "Communicator volume"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Connection\Connect.cs:186
+#: top_speed_net/TopSpeed/Core/Multiplayer/Connection/Connect.cs
 msgid "Compatibility warning"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Main.cs:42
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
+#, csharp-format
+msgid "Completing lap {0}"
+msgstr ""
+
+#: top_speed_net/TopSpeed/Menu/Build/Options/Main.cs
 msgid ""
 "Configure default multiplayer hosting settings, including the server port "
 "used by the game."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Main.cs:15
+#: top_speed_net/TopSpeed/Menu/Build/Options/Main.cs
 msgid ""
 "Configure general gameplay and interface behavior, including units, usage "
 "hints, menu behavior, and update checking."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Main.cs:34
+#: top_speed_net/TopSpeed/Menu/Build/Options/Main.cs
 msgid ""
 "Configure input devices, force feedback, progressive keyboard behavior, key "
 "mappings, and menu shortcut mappings."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Main.cs:23
+#: top_speed_net/TopSpeed/Menu/Build/Options/Main.cs
 msgid ""
 "Configure spatial audio behavior, including HRTF processing, stereo "
 "widening, automatic device format detection, and voice input device "
 "selection."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Main.cs:19
+#: top_speed_net/TopSpeed/Menu/Build/Options/Main.cs
 msgid ""
 "Configure speech behavior, including screen-reader backend selection and "
 "screen-reader calibration."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Menus.cs:61
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Menus.cs
 msgid "Confirm game options"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:9
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "Congratulations! You have made it to the first position."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Connection\Connect.cs:156
+#: top_speed_net/TopSpeed/Core/Multiplayer/Connection/Connect.cs
 msgid "Connected to server."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Connect\Result\ConnectResult.cs:83
+#: top_speed_net/TopSpeed/Network/Connect/Result/ConnectResult.cs
 msgid "Connected."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Coordinator\PendingOperations.cs:57
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Connect\Connector\Connect.cs:217
+#: top_speed_net/TopSpeed/Core/Multiplayer/Coordinator/PendingOperations.cs
+#: top_speed_net/TopSpeed/Network/Connect/Connector/Connect.cs
 msgid "Connection attempt canceled."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Coordinator\PendingOperations.cs:69
+#: top_speed_net/TopSpeed/Core/Multiplayer/Coordinator/PendingOperations.cs
 msgid "Connection attempt failed."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Coordinator\PendingOperations.cs:65
+#: top_speed_net/TopSpeed/Core/Multiplayer/Coordinator/PendingOperations.cs
 #, csharp-format
 msgid "Connection attempt failed: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Connection\Connect.cs:213
+#: top_speed_net/TopSpeed/Core/Multiplayer/Connection/Connect.cs
 msgid "Connection canceled."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\DisconnectMapping.cs:87
+#: top_speed_net/TopSpeed/Network/DisconnectMapping.cs
 msgid "Connection changed. Reconnecting."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\DisconnectMapping.cs:42
+#: top_speed_net/TopSpeed/Network/DisconnectMapping.cs
 msgid "Connection closed by server."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\DisconnectMapping.cs:52
+#: top_speed_net/TopSpeed/Network/DisconnectMapping.cs
 msgid "Connection closed due to protocol error."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Connection\Connect.cs:235
+#: top_speed_net/TopSpeed/Core/Multiplayer/Connection/Connect.cs
 msgid "Connection failed"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Connect\Result\ConnectResult.cs:98
+#: top_speed_net/TopSpeed/Network/Connect/Result/ConnectResult.cs
 msgid "Connection failed."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Connect\Connector\Connect.cs:138
+#: top_speed_net/TopSpeed/Network/Connect/Connector/Connect.cs
 #, csharp-format
 msgid "Connection failed: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Connect\Result\ConnectResult.cs:76
+#: top_speed_net/TopSpeed/Network/Connect/Result/ConnectResult.cs
 msgid "Connection lost before session initialization."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Connect\Connector\Connect.cs:45
-#: D:\top_speed\top_speed_net\TopSpeed\Network\DisconnectMapping.cs:97
+#: top_speed_net/TopSpeed/Network/Connect/Connector/Connect.cs
+#: top_speed_net/TopSpeed/Network/DisconnectMapping.cs
 msgid "Connection lost."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Reconnect.cs:27
+#: top_speed_net/TopSpeed/Game/Multiplayer/Reconnect.cs
 msgid "Connection lost. Reconnecting."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Connect\Connector\Poll.cs:128
+#: top_speed_net/TopSpeed/Network/Connect/Connector/Poll.cs
 msgid "Connection refused by server."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Connect\Connector\Helpers.cs:128
+#: top_speed_net/TopSpeed/Network/Connect/Connector/Helpers.cs
 msgid "Connection refused due to protocol mismatch."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\DisconnectMapping.cs:57
+#: top_speed_net/TopSpeed/Network/DisconnectMapping.cs
 msgid "Connection rejected by server."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\DisconnectMapping.cs:37
+#: top_speed_net/TopSpeed/Network/DisconnectMapping.cs
 msgid "Connection timed out."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:96
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "Consider that your one free mistake for the session."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Menu\Wizard.cs:16
+#: top_speed_net/TopSpeed/Game/Menu/Wizard.cs
 msgid "Continue"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Connection\Connect.cs:191
+#: top_speed_net/TopSpeed/Core/Multiplayer/Connection/Connect.cs
 msgid "Continue connection"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\ModifierKeys.cs:115
+#: top_speed_net/TopSpeed/Input/ModifierKeys.cs
 msgid "Control"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Panels\ControlPanel.cs:5
+#: top_speed_net/TopSpeed/Drive/Panels/ControlPanel.cs
 msgid "Control panel"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:73
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Controller"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Input.cs:32
+#: top_speed_net/TopSpeed/Game/Settings/Input.cs
 msgid "Controller backend unavailable"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Settings\Manager\Apply\Input.cs:36
+#: top_speed_net/TopSpeed/Core/Settings/Manager/Apply/Input.cs
 msgid ""
 "Controller bindings section is missing. Defaults were used for controller "
 "bindings."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Input.cs:117
+#: top_speed_net/TopSpeed/Game/Settings/Input.cs
 msgid "Controller mappings restored to defaults."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Menu\Device.cs:53
+#: top_speed_net/TopSpeed/Game/Menu/Device.cs
 msgid "Controller selected."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Menu\Device.cs:51
+#: top_speed_net/TopSpeed/Game/Menu/Device.cs
 #, csharp-format
 msgid "Controller selected. {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Backends\Sdl\Discovery\Display.cs:34
+#: top_speed_net/TopSpeed/Input/Backends/Sdl/Discovery/Display.cs
 #, csharp-format
 msgid "Controller {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Main.cs:31
+#: top_speed_net/TopSpeed/Menu/Build/Options/Main.cs
 msgid "Controls"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Volume.cs:72
+#: top_speed_net/TopSpeed/Menu/Build/Options/Volume.cs
 msgid ""
 "Controls communicator activation cues and remote voice chat playback. "
 "Affects how loud other players sound when they speak through the "
 "communicator."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Volume.cs:33
+#: top_speed_net/TopSpeed/Menu/Build/Options/Volume.cs
 msgid ""
 "Controls engine-related sounds for bots and other players, including engine "
 "start and stop."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Volume.cs:28
+#: top_speed_net/TopSpeed/Menu/Build/Options/Volume.cs
 msgid ""
 "Controls events related to your own vehicle, such as horn, back-fire, and "
 "other vehicle events."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Volume.cs:38
+#: top_speed_net/TopSpeed/Menu/Build/Options/Volume.cs
 msgid ""
 "Controls horns, crashes, bumps, brakes, and similar event sounds for bots "
 "and other players."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Volume.cs:62
+#: top_speed_net/TopSpeed/Menu/Build/Options/Volume.cs
 msgid ""
 "Controls menu and race music volume. This stays synchronized with the menu "
 "music volume setting."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Volume.cs:48
+#: top_speed_net/TopSpeed/Menu/Build/Options/Volume.cs
 msgid ""
 "Controls radio playback volume from other players only. Your own radio "
 "playback is not affected."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Volume.cs:43
+#: top_speed_net/TopSpeed/Menu/Build/Options/Volume.cs
 msgid "Controls road and surface loops like asphalt, gravel, etc."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Volume.cs:67
+#: top_speed_net/TopSpeed/Menu/Build/Options/Volume.cs
 msgid ""
 "Controls server and multiplayer event sounds such as connection and other "
 "events."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Volume.cs:18
+#: top_speed_net/TopSpeed/Menu/Build/Options/Volume.cs
 msgid ""
 "Controls the overall audio volume for the game. Set lower to reduce every "
 "sound category."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Volume.cs:53
+#: top_speed_net/TopSpeed/Menu/Build/Options/Volume.cs
 msgid ""
 "Controls track ambients, weather loops, noise sounds, and custom track sound "
 "sources."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Volume.cs:23
+#: top_speed_net/TopSpeed/Menu/Build/Options/Volume.cs
 msgid ""
 "Controls your own engine and throttle sounds, including engine start and "
 "stop."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Menu\About.cs:48
+#: top_speed_net/TopSpeed/Game/Menu/About.cs
 msgid "Copied to clipboard."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Coordinator\Chat\History.cs:176
+#: top_speed_net/TopSpeed/Core/Multiplayer/Coordinator/Chat/History.cs
 msgid "Copied."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:146
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Copies the currently focused multiplayer history item to the clipboard."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Drive.cs:16
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
 msgid "Copilot"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Menu\About.cs:35
+#: top_speed_net/TopSpeed/Game/Menu/About.cs
 msgid "Copy"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:145
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Copy focused history item"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Panels\RadioPanel\Playlist.cs:66
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Communicator\Runtime\MediaLocal.cs:453
+#: top_speed_net/TopSpeed/Drive/Panels/RadioPanel/Playlist.cs
+#: top_speed_net/TopSpeed/Game/Multiplayer/Communicator/Runtime/MediaLocal.cs
 msgid "Could not read files from the selected folder."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Multiplayer.cs:28
+#: top_speed_net/TopSpeed/Menu/Build/Multiplayer.cs
 msgid "Create a new game"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Menu\LobbyAndControls.cs:14
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Menu/LobbyAndControls.cs
 msgid "Create a new game room"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Create.cs:55
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Create.cs
 msgid "Create this game room"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Drive\Bind.cs:46
+#: top_speed_net/TopSpeed/Input/Drive/Bind.cs
 msgid "Current gear"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Drive\Bind.cs:47
+#: top_speed_net/TopSpeed/Input/Drive/Bind.cs
 msgid "Current lap number"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Drive\Bind.cs:49
+#: top_speed_net/TopSpeed/Input/Drive/Bind.cs
 msgid "Current lap percentage"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Drive\Bind.cs:48
+#: top_speed_net/TopSpeed/Input/Drive/Bind.cs
 msgid "Current race percentage"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Drive\Bind.cs:50
+#: top_speed_net/TopSpeed/Input/Drive/Bind.cs
 msgid "Current race time"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Drive.cs:26
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
+msgid "Curve announcement method"
+msgstr ""
+
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
 msgid "Curve announcements"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Drive\Vehicles.cs:22
+#: top_speed_net/TopSpeed/Menu/Build/Drive/Vehicles.cs
 msgid "Custom"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Protocol\TrackPackages\Build\Identity.cs:26
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Formatting.cs:61
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\TrackSelection.cs:51
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Selection\TrackSource.cs:43
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:144
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\TrackPackages\State.cs:57
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Drive\Tracks.cs:17
+#: top_speed_net/TopSpeed.Shared/Protocol/TrackPackages/Build/Identity.cs
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Formatting.cs
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/TrackSelection.cs
+#: top_speed_net/TopSpeed/Core/Selection/TrackSource.cs
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
+#: top_speed_net/TopSpeed/Game/Multiplayer/TrackPackages/State.cs
+#: top_speed_net/TopSpeed/Menu/Build/Drive/Tracks.cs
 msgid "Custom track"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Drive\Tracks.cs:94
+#: top_speed_net/TopSpeed/Menu/Build/Drive/Tracks.cs
 msgid "Custom track errors"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\TrackPackages\UploadBuild.cs:16
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/TrackPackages/UploadBuild.cs
 msgid "Custom track file path is empty."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Drive\Tracks.cs:112
+#: top_speed_net/TopSpeed/Menu/Build/Drive/Tracks.cs
 msgid "Custom track issues"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Menus.cs:91
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Menus.cs
 msgid "Custom tracks"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\TrackPackages\Catalog.cs:57
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/TrackPackages/Catalog.cs
 msgid "Custom tracks are disabled for this room."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Selection\VehicleSource.cs:70
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Drive\Vehicles.cs:48
+#: top_speed_net/TopSpeed/Core/Selection/VehicleSource.cs
+#: top_speed_net/TopSpeed/Menu/Build/Drive/Vehicles.cs
 msgid "Custom vehicle"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Drive\Vehicles.cs:82
+#: top_speed_net/TopSpeed/Menu/Build/Drive/Vehicles.cs
 msgid "Custom vehicle errors"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Core\Load\File.cs:35
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Core/Load/File.cs
 msgid "Custom vehicle file must use .tsv extension."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Drive\Vehicles.cs:99
+#: top_speed_net/TopSpeed/Menu/Build/Drive/Vehicles.cs
 msgid "Custom vehicle issues"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\VolumeShortcuts.cs:49
+#: top_speed_net/TopSpeed/Game/Settings/VolumeShortcuts.cs
 msgid "Cycles to the next global volume category."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\VolumeShortcuts.cs:58
+#: top_speed_net/TopSpeed/Game/Settings/VolumeShortcuts.cs
 msgid "Cycles to the previous global volume category."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:205
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "D-pad down"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:206
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "D-pad left"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:204
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "D-pad right"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:203
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "D-pad up"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:43
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Decimal"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:249
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Decrease media volume"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\VolumeShortcuts.cs:66
+#: top_speed_net/TopSpeed/Game/Settings/VolumeShortcuts.cs
 msgid "Decrease volume by 1"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\VolumeShortcuts.cs:84
+#: top_speed_net/TopSpeed/Game/Settings/VolumeShortcuts.cs
 msgid "Decrease volume by 10"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:250
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Decreases media volume."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\VolumeShortcuts.cs:67
+#: top_speed_net/TopSpeed/Game/Settings/VolumeShortcuts.cs
 msgid "Decreases the selected global volume category by one step."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\VolumeShortcuts.cs:85
+#: top_speed_net/TopSpeed/Game/Settings/VolumeShortcuts.cs
 msgid "Decreases the selected global volume category by ten steps."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:121
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Default (1 degree)"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Connection\Prompt.cs:89
+#: top_speed_net/TopSpeed/Core/Multiplayer/Connection/Prompt.cs
 msgid "Default call sign cleared."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Connection\Prompt.cs:94
+#: top_speed_net/TopSpeed/Core/Multiplayer/Connection/Prompt.cs
 #, csharp-format
 msgid "Default call sign set to {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\SavedServers\Form.cs:38
+#: top_speed_net/TopSpeed/Core/Multiplayer/SavedServers/Form.cs
 msgid "Default call sign, currently empty."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\SavedServers\Form.cs:40
+#: top_speed_net/TopSpeed/Core/Multiplayer/SavedServers/Form.cs
 #, csharp-format
 msgid "Default call sign, currently set to {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Server.cs:20
+#: top_speed_net/TopSpeed/Menu/Build/Options/Server.cs
 msgid "Default call sign: not set"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Server.cs:22
+#: top_speed_net/TopSpeed/Menu/Build/Options/Server.cs
 #, csharp-format
 msgid "Default call sign: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Connection\Prompt.cs:18
+#: top_speed_net/TopSpeed/Core/Multiplayer/Connection/Prompt.cs
 #, csharp-format
 msgid "Default server port reset to {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Connection\Prompt.cs:32
+#: top_speed_net/TopSpeed/Core/Multiplayer/Connection/Prompt.cs
 #, csharp-format
 msgid "Default server port set to {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Server.cs:14
+#: top_speed_net/TopSpeed/Menu/Build/Options/Server.cs
 #, csharp-format
 msgid "Default server port: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Core.cs:37
+#: top_speed_net/TopSpeed/Game/Settings/Core.cs
 msgid "Defaults restored."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\SavedServers\Menu.cs:30
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:76
+#: top_speed_net/TopSpeed/Core/Multiplayer/SavedServers/Menu.cs
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Delete"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\SavedServers\Delete.cs:16
+#: top_speed_net/TopSpeed/Core/Multiplayer/SavedServers/Delete.cs
 msgid "Delete this server?"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Dialogs\Dialog.cs:81
+#: top_speed_net/TopSpeed/Menu/Dialogs/Dialog.cs
 msgid "Dialog"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\Room.cs:126
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Setup.cs:95
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/Room.cs
+#: top_speed_net/TopSpeed/Game/Drive/Setup.cs
 msgid "Disable for this race"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\SavedServers\Form.cs:67
+#: top_speed_net/TopSpeed/Core/Multiplayer/SavedServers/Form.cs
 msgid "Discard changes"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Connection\Connect.cs:192
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Multiplayer.cs:31
+#: top_speed_net/TopSpeed/Core/Multiplayer/Connection/Connect.cs
+#: top_speed_net/TopSpeed/Menu/Build/Multiplayer.cs
 msgid "Disconnect"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Menu\LobbyAndControls.cs:18
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Menu/LobbyAndControls.cs
 msgid "Disconnect from server"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Session.cs:12
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Dispatch\Control.cs:23
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Session.cs
+#: top_speed_net/TopSpeed/Game/Multiplayer/Dispatch/Control.cs
 msgid "Disconnected from server."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\DisconnectMapping.cs:47
+#: top_speed_net/TopSpeed/Network/DisconnectMapping.cs
 msgid "Disconnected."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:62
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Divide"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\LoadoutExit.cs:33
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/LoadoutExit.cs
 msgid "Do you want to quit race preparation and stay in this game room?"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:73
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Down"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Download.cs:114
+#: top_speed_net/TopSpeed/Game/Updates/Download.cs
 msgid "Download failed"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Updates\Service.cs:149
+#: top_speed_net/TopSpeed/Core/Updates/Service.cs
 #, csharp-format
 msgid "Download failed with status code {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Updates\Service.cs:219
+#: top_speed_net/TopSpeed/Core/Updates/Service.cs
 #, csharp-format
 msgid "Download failed: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Updates\Service.cs:209
+#: top_speed_net/TopSpeed/Core/Updates/Service.cs
 msgid "Download timed out or was canceled."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Check.cs:208
+#: top_speed_net/TopSpeed/Game/Updates/Check.cs
 msgid "Download update"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\TrackPackages\DownloadProgress.cs:42
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Dialog.cs:18
+#: top_speed_net/TopSpeed/Game/Multiplayer/TrackPackages/DownloadProgress.cs
+#: top_speed_net/TopSpeed/Game/Updates/Dialog.cs
 #, csharp-format
 msgid "Downloaded size: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\TrackPackages\DownloadProgress.cs:46
+#: top_speed_net/TopSpeed/Game/Multiplayer/TrackPackages/DownloadProgress.cs
 msgid "Downloading track..."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Dialog.cs:22
+#: top_speed_net/TopSpeed/Game/Updates/Dialog.cs
 msgid "Downloading update..."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Vehicles\Catalog\Data.cs:366
+#: top_speed_net/TopSpeed.Shared/Vehicles/Catalog/Data.cs
 msgid "Ducati Panigale V4"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Core\Load\Sections.cs:65
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Core/Load/Sections.cs
 #, csharp-format
 msgid "Duplicate key '{0}' in section [{1}] is not allowed."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:74
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 #, csharp-format
 msgid "Duplicate room id '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Core\Load\Sections.cs:33
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Core/Load/Sections.cs
 #, csharp-format
 msgid "Duplicate section [{0}] is not allowed."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:62
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 #, csharp-format
 msgid "Duplicate segment id '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:79
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 #, csharp-format
 msgid "Duplicate sound id '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:69
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 #, csharp-format
 msgid "Duplicate weather id '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\SavedServers\Menu.cs:29
+#: top_speed_net/TopSpeed/Core/Multiplayer/SavedServers/Menu.cs
 msgid "Edit"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Game.cs:85
+#: top_speed_net/TopSpeed/Menu/Build/Options/Game.cs
 msgid "Edit the proxy URL used for update package downloads."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Audio.cs:13
+#: top_speed_net/TopSpeed/Menu/Build/Options/Audio.cs
 msgid "Enable HRTF audio"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Menus.cs:97
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Drive.cs:72
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Menus.cs
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
 msgid "Enable fuel consumption"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Game.cs:59
+#: top_speed_net/TopSpeed/Menu/Build/Options/Game.cs
 msgid "Enable menu navigation panning"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Game.cs:53
+#: top_speed_net/TopSpeed/Menu/Build/Options/Game.cs
 msgid "Enable menu wrapping"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Menus.cs:103
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Drive.cs:76
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Menus.cs
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
 msgid "Enable tire wear"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Proxy.cs:22
+#: top_speed_net/TopSpeed/Game/Settings/Proxy.cs
 msgid "Enable update download proxy first."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Game.cs:44
+#: top_speed_net/TopSpeed/Menu/Build/Options/Game.cs
 msgid "Enable usage hints"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:32
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Enables force feedback or vibration if your controller supports it."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:72
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "End"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\TrackList.cs:30
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:106
+#: top_speed_net/TopSpeed/Core/TrackList.cs
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
 msgid "England"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Localization\ClientLanguages.cs:27
-#: D:\top_speed\top_speed_net\TopSpeed\Localization\ClientLanguages.cs:35
+#: top_speed_net/TopSpeed/Localization/ClientLanguages.cs
 msgid "English (Original)"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\TrackList.cs:48
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:134
+#: top_speed_net/TopSpeed/Core/TrackList.cs
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
 msgid "English country"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:25
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Enter"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Create.cs:52
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Create.cs
 msgid "Enter a room name. Leave it empty to use an automatic name."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Create.cs:78
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Create.cs
 msgid ""
 "Enter a room name. Leave this field empty to use an automatic room name."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Proxy.cs:27
+#: top_speed_net/TopSpeed/Game/Settings/Proxy.cs
 msgid "Enter proxy URL"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Multiplayer.cs:14
+#: top_speed_net/TopSpeed/Menu/Build/Multiplayer.cs
 msgid "Enter the IP address or domain manually"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\SavedServers\Draft.cs:78
+#: top_speed_net/TopSpeed/Core/Multiplayer/SavedServers/Draft.cs
 msgid ""
 "Enter the default call sign for this server. Leave empty to use the global "
 "default call sign."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Connection\Connection.cs:53
+#: top_speed_net/TopSpeed/Core/Multiplayer/Connection/Connection.cs
 msgid ""
 "Enter the default call sign used when connecting to servers. Leave empty to "
 "clear it."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Connection\Connection.cs:37
+#: top_speed_net/TopSpeed/Core/Multiplayer/Connection/Connection.cs
 msgid "Enter the default server port used for manual connections."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Connection\Prompt.cs:45
+#: top_speed_net/TopSpeed/Core/Multiplayer/Connection/Prompt.cs
 msgid "Enter the server IP address or domain."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\SavedServers\Draft.cs:29
+#: top_speed_net/TopSpeed/Core/Multiplayer/SavedServers/Draft.cs
 msgid "Enter the server IP address or host name."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\SavedServers\Draft.cs:12
+#: top_speed_net/TopSpeed/Core/Multiplayer/SavedServers/Draft.cs
 msgid "Enter the server name."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\SavedServers\Draft.cs:47
+#: top_speed_net/TopSpeed/Core/Multiplayer/SavedServers/Draft.cs
 msgid "Enter the server port, or leave empty for default."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Connection\Prompt.cs:67
+#: top_speed_net/TopSpeed/Core/Multiplayer/Connection/Prompt.cs
 msgid "Enter your call sign."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Coordinator\Chat\Input.cs:20
+#: top_speed_net/TopSpeed/Core/Multiplayer/Coordinator/Chat/Input.cs
 msgid "Enter your global chat message."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Coordinator\Chat\Input.cs:43
+#: top_speed_net/TopSpeed/Core/Multiplayer/Coordinator/Chat/Input.cs
 msgid "Enter your room chat message."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:20
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Equals"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Issues\Issue.cs:22
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Selection\VehicleSource.cs:89
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Issues/Issue.cs
+#: top_speed_net/TopSpeed/Core/Selection/VehicleSource.cs
 msgid "Error"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Issues.cs:100
+#: top_speed_net/TopSpeed/Game/Settings/Issues.cs
 msgid "Error:"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:18
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Escape"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:147
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "Even the walls were probably tired of this by the end."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:36
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "Excellent driving. You beat your previous best time."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Core.cs:155
+#: top_speed_net/TopSpeed/Menu/Build/Core.cs
 msgid "Exit Game"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Connect\Connector\Connect.cs:112
+#: top_speed_net/TopSpeed/Network/Connect/Connector/Connect.cs
 msgid "Failed to initialize network client."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Communicator\Runtime\MediaLocal.cs:295
+#: top_speed_net/TopSpeed/Game/Multiplayer/Communicator/Runtime/MediaLocal.cs
 #, csharp-format
 msgid "Failed to load communicator media. {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\loader\Custom.cs:28
+#: top_speed_net/TopSpeed/Vehicles/loader/Custom.cs
 #, csharp-format
 msgid "Failed to load custom vehicle '{0}'. {1}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Panels\RadioPanel\Playback.cs:89
+#: top_speed_net/TopSpeed/Drive/Panels/RadioPanel/Playback.cs
 #, csharp-format
 msgid "Failed to load radio media. {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Selection\TrackSource.cs:54
-#: D:\top_speed\top_speed_net\TopSpeed\Tracks\TrackLoadException.cs:40
+#: top_speed_net/TopSpeed/Core/Selection/TrackSource.cs
+#: top_speed_net/TopSpeed/Tracks/TrackLoadException.cs
 msgid "Failed to load this track file."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Selection\VehicleSource.cs:82
+#: top_speed_net/TopSpeed/Core/Selection/VehicleSource.cs
 msgid "Failed to load this vehicle file."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Tracks\TrackLoadException.cs:13
+#: top_speed_net/TopSpeed/Tracks/TrackLoadException.cs
 #, csharp-format
 msgid "Failed to load track '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Live\Tx.cs:56
+#: top_speed_net/TopSpeed/Network/Live/Tx.cs
 msgid "Failed to open local radio media for live streaming."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Coordinator\Chat\Input.cs:70
+#: top_speed_net/TopSpeed/Core/Multiplayer/Coordinator/Chat/Input.cs
 msgid "Failed to send chat message."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Connect\Connector\Helpers.cs:169
+#: top_speed_net/TopSpeed/Network/Connect/Connector/Helpers.cs
 msgid "Failed to send handshake."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Connect\Connector\Helpers.cs:58
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Connect\Connector\Helpers.cs:64
+#: top_speed_net/TopSpeed/Network/Connect/Connector/Helpers.cs
 #, csharp-format
 msgid "Failed to send handshake: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Coordinator\Chat\Input.cs:99
+#: top_speed_net/TopSpeed/Core/Multiplayer/Coordinator/Chat/Input.cs
 msgid "Failed to send room chat message."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Coordinator\Helpers.cs:71
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Quit.cs:35
+#: top_speed_net/TopSpeed/Core/Multiplayer/Coordinator/Helpers.cs
+#: top_speed_net/TopSpeed/Game/Multiplayer/Quit.cs
 #, csharp-format
 msgid "Failed to send {0}. Please check your connection."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Communicator\Runtime\MediaLocal.cs:301
+#: top_speed_net/TopSpeed/Game/Multiplayer/Communicator/Runtime/MediaLocal.cs
 msgid "Failed to stream communicator media to the server."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:38
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Fast (0.50 seconds)"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:37
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Fastest (0.25 seconds)"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:184
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 #, csharp-format
 msgid "Fastest recorded lap on this track: {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Check.cs:108
+#: top_speed_net/TopSpeed/Game/Updates/Check.cs
 msgid "Fetching latest changes."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Vehicles\Catalog\Data.cs:118
+#: top_speed_net/TopSpeed.Shared/Vehicles/Catalog/Data.cs
 msgid "Fiat 500"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\TrackPackages\UploadProgress.cs:28
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\TrackPackages\DownloadProgress.cs:41
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Dialog.cs:17
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/TrackPackages/UploadProgress.cs
+#: top_speed_net/TopSpeed/Game/Multiplayer/TrackPackages/DownloadProgress.cs
+#: top_speed_net/TopSpeed/Game/Updates/Dialog.cs
 #, csharp-format
 msgid "File size: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Selection\SourceBase.cs:80
+#: top_speed_net/TopSpeed/Core/Selection/SourceBase.cs
 #, csharp-format
 msgid "File: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:18
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "Final results are ready."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\TrackList.cs:31
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:108
+#: top_speed_net/TopSpeed/Core/TrackList.cs
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
 msgid "Finland"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:113
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "First history item"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:11
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "First position achieved. Great race."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:29
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Force feedback"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Vehicles\Catalog\Data.cs:178
+#: top_speed_net/TopSpeed.Shared/Vehicles/Catalog/Data.cs
 msgid "Ford Mustang 1969"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\TrackList.cs:32
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:110
+#: top_speed_net/TopSpeed/Core/TrackList.cs
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
 msgid "France"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\TrackList.cs:47
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:132
+#: top_speed_net/TopSpeed/Core/TrackList.cs
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
 msgid "French coast"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Coordinator\Communicator.cs:51
+#: top_speed_net/TopSpeed/Core/Multiplayer/Coordinator/Communicator.cs
 msgid "Frequency must be between 0.0 and 1000.0 in 0.1 steps."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Coordinator\Communicator.cs:58
+#: top_speed_net/TopSpeed/Core/Multiplayer/Coordinator/Communicator.cs
 #, csharp-format
 msgid "Frequency set to {0} MHz."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\TrackPackages\UploadProgress.cs:53
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Dialog.cs:66
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/TrackPackages/UploadProgress.cs
+#: top_speed_net/TopSpeed/Game/Updates/Dialog.cs
 msgid "GB"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Core.cs:168
+#: top_speed_net/TopSpeed/Menu/Build/Core.cs
 msgid "Game guide"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Menus.cs:28
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Menus.cs
 msgid "Game rules"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Chat\HistoryText.cs:113
+#: top_speed_net/TopSpeed/Core/Multiplayer/Chat/HistoryText.cs
 msgid "Game rules changed."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Create.cs:34
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Create.cs
 msgid "Game type"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Menu\About.cs:16
+#: top_speed_net/TopSpeed/Game/Menu/About.cs
 #, csharp-format
 msgid "Game version: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Backends\Sdl\Discovery\Display.cs:44
+#: top_speed_net/TopSpeed/Input/Backends/Sdl/Discovery/Display.cs
 msgid "Gamepad"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Systems\CoreRequests.cs:119
+#: top_speed_net/TopSpeed/Drive/Session/Systems/CoreRequests.cs
 #, csharp-format
 msgid "Gear {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Main.cs:12
+#: top_speed_net/TopSpeed/Menu/Build/Options/Main.cs
 msgid "General"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\TrackList.cs:33
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:112
+#: top_speed_net/TopSpeed/Core/TrackList.cs
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
 msgid "Germany"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Menus.cs:85
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Menus.cs
 msgid "Ghost mode"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Rules.cs:50
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Rules.cs
 #, csharp-format
 msgid ""
 "Ghost mode is {0}. Custom tracks are {1}. Fuel consumption is {2}. Tire wear "
@@ -1561,63 +1562,63 @@ msgid ""
 "limited to {6}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:152
-#: D:\top_speed\top_speed_net\TopSpeed\Shortcuts\Catalog.cs:137
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
+#: top_speed_net/TopSpeed/Shortcuts/Catalog.cs
 msgid "Global shortcuts"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Race\Runtime.cs:287
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Runtime\Screen\Core.cs:259
+#: top_speed_net/TopSpeed/Game/Multiplayer/Race/Runtime.cs
+#: top_speed_net/TopSpeed/Menu/Runtime/Screen/Core.cs
 msgid "Go back"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:29
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Grave"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Core.cs:152
+#: top_speed_net/TopSpeed/Menu/Build/Core.cs
 msgid "Help"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Menu\Help.cs:49
+#: top_speed_net/TopSpeed/Game/Menu/Help.cs
 msgid "Help file not found"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:24
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "Here are the final standings for everyone."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:29
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "Here are the final standings."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Core.cs:58
+#: top_speed_net/TopSpeed/Menu/Build/Core.cs
 msgid "History"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:178
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Hold to transmit voice when voice activation is off."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:67
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Home"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\DisconnectMapping.cs:72
+#: top_speed_net/TopSpeed/Network/DisconnectMapping.cs
 msgid "Host is unreachable."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Drive.cs:93
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
 msgid ""
 "How many laps should the race be? This applies to single race, time trial, "
 "and multiplayer modes."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:156
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 msgid "Humidity must be between 0 and 1."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Core\State.cs:121
+#: top_speed_net/TopSpeed/Game/Core/State.cs
 msgid ""
 "I really have nothing interesting to put here not even the secret to life "
 "except this really long run on sentence that is probably the most boring "
@@ -1625,481 +1626,488 @@ msgid ""
 "screen reader is speaking."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\LoadoutExit.cs:24
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/LoadoutExit.cs
 msgid ""
 "If you leave race preparation now, the current game will be canceled for "
 "everyone in this room."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Game.cs:30
+#: top_speed_net/TopSpeed/Menu/Build/Options/Game.cs
 msgid "Include custom tracks in randomization"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Game.cs:34
+#: top_speed_net/TopSpeed/Menu/Build/Options/Game.cs
 msgid "Include custom vehicles in randomization"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:240
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Increase media volume"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\VolumeShortcuts.cs:75
+#: top_speed_net/TopSpeed/Game/Settings/VolumeShortcuts.cs
 msgid "Increase volume by 1"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\VolumeShortcuts.cs:93
+#: top_speed_net/TopSpeed/Game/Settings/VolumeShortcuts.cs
 msgid "Increase volume by 10"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:241
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Increases media volume."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\VolumeShortcuts.cs:76
+#: top_speed_net/TopSpeed/Game/Settings/VolumeShortcuts.cs
 msgid "Increases the selected global volume category by one step."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\VolumeShortcuts.cs:94
+#: top_speed_net/TopSpeed/Game/Settings/VolumeShortcuts.cs
 msgid "Increases the selected global volume category by ten steps."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Issues.cs:104
+#: top_speed_net/TopSpeed/Game/Settings/Issues.cs
 msgid "Info:"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:75
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Insert"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Speech.cs:58
+#: top_speed_net/TopSpeed/Menu/Build/Options/Speech.cs
 msgid "Interrupt screen reader speech"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:111
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 #, csharp-format
 msgid "Invalid ambience value '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:258
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:115
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 #, csharp-format
 msgid "Invalid boolean '{0}' for key '{1}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Policy\PolicyValidation.cs:58
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Policy/PolicyValidation.cs
 #, csharp-format
 msgid "Invalid key '{0}'. Source gear must be within 1..{1}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Policy\PolicyValidation.cs:70
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Policy/PolicyValidation.cs
 #, csharp-format
 msgid "Invalid key '{0}'. Use upshift_delay_X_Y for adjacent gears."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Core\Load\Sections.cs:45
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Core/Load/Sections.cs
 msgid "Invalid line. Expected [section] or key=value."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:292
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Invalid numeric value '{0}' for key '{1}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:109
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Invalid pit value '{0}'. Use pit_entry or pit_exit."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Connection\Prompt.cs:25
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\SavedServers\Draft.cs:66
+#: top_speed_net/TopSpeed/Core/Multiplayer/Connection/Prompt.cs
+#: top_speed_net/TopSpeed/Core/Multiplayer/SavedServers/Draft.cs
 msgid "Invalid port. Enter a number between 1 and 65535."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:307
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Invalid room override value '{0}' for key '{1}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:193
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Invalid room value '{0}' for key '{1}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:60
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Invalid segment height '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:44
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Invalid segment length '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:37
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Invalid segment noise '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:30
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Invalid segment surface '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:23
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Invalid segment type '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:53
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Invalid segment width '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Protocol\TrackPackages\Build\Assets.cs:65
+#: top_speed_net/TopSpeed.Shared/Protocol/TrackPackages/Build/Assets.cs
 #, csharp-format
 msgid "Invalid sound asset path: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:251
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Invalid sound random mode '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:213
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Invalid sound type '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Torque\TorqueCurve.cs:62
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Torque/TorqueCurve.cs
 #, csharp-format
 msgid "Invalid torque curve key '{0}'. Use format like 2000rpm=200."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Torque\TorqueCurve.cs:71
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Torque/TorqueCurve.cs
 #, csharp-format
 msgid "Invalid torque value '{0}' for '{1}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:285
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Invalid vector '{0}' for key '{1}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:125
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Invalid weather kind '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:77
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Invalid weather transition seconds '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:134
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:140
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Invalid weather value '{0}' for key '{1}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:93
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:103
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:113
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Inverted"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\TrackList.cs:34
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:114
+#: top_speed_net/TopSpeed/Core/TrackList.cs
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
 msgid "Ireland"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\TrackList.cs:35
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:116
+#: top_speed_net/TopSpeed/Core/TrackList.cs
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
 msgid "Italy"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Multiplayer.cs:12
+#: top_speed_net/TopSpeed/Menu/Build/Multiplayer.cs
 msgid "Join a game on the local network"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Menu\LobbyAndControls.cs:15
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Multiplayer.cs:29
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Menu/LobbyAndControls.cs
+#: top_speed_net/TopSpeed/Menu/Build/Multiplayer.cs
 msgid "Join an existing game"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Backends\Sdl\Discovery\Display.cs:46
+#: top_speed_net/TopSpeed/Input/Backends/Sdl/Discovery/Display.cs
 msgid "Joystick"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\TrackPackages\UploadProgress.cs:51
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Dialog.cs:64
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/TrackPackages/UploadProgress.cs
+#: top_speed_net/TopSpeed/Game/Updates/Dialog.cs
 msgid "KB"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Vehicles\Catalog\Data.cs:336
+#: top_speed_net/TopSpeed.Shared/Vehicles/Catalog/Data.cs
 msgid "Kawasaki Ninja ZX-10R"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Core\Readers\FloatCsv.cs:24
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Core/Readers/FloatCsv.cs
 #, csharp-format
 msgid "Key '{0}' contains a non-float value '{1}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Core\Readers\Text.cs:18
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Core/Readers/Text.cs
 #, csharp-format
 msgid "Key '{0}' in section [{1}] must not be empty."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:101
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 #, csharp-format
 msgid "Key '{0}' is missing a value."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Core\Readers\Bools.cs:21
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Core\Readers\Bools.cs:35
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Core/Readers/Bools.cs
 #, csharp-format
 msgid "Key '{0}' must be a boolean or 0/1 integer."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Core\Readers\Numbers.cs:50
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Core\Readers\Numbers.cs:76
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Core/Readers/Numbers.cs
 #, csharp-format
 msgid "Key '{0}' must be a float."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Core\Readers\Numbers.cs:18
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Core\Readers\Numbers.cs:33
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Core/Readers/Numbers.cs
 #, csharp-format
 msgid "Key '{0}' must be an integer."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Core\Readers\FloatCsv.cs:33
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Core/Readers/FloatCsv.cs
 #, csharp-format
 msgid "Key '{0}' must contain at least one float value."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Core\Readers\Text.cs:40
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Core/Readers/Text.cs
 #, csharp-format
 msgid "Key '{0}' must contain at least one path."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Transmission\Types.cs:68
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Transmission/Types.cs
 #, csharp-format
 msgid "Key '{0}' must contain at least one transmission type."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Core\Readers\Numbers.cs:23
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Core\Readers\Numbers.cs:60
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Core\Readers\Numbers.cs:95
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Core/Readers/Numbers.cs
 #, csharp-format
 msgid "Key '{0}' value {1} is outside allowed range {2} to {3}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:72
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Keyboard"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Settings\Manager\Apply\Input.cs:26
+#: top_speed_net/TopSpeed/Core/Settings/Manager/Apply/Input.cs
 msgid ""
 "Keyboard bindings section is missing. Defaults were used for keyboard "
 "bindings."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Input.cs:116
+#: top_speed_net/TopSpeed/Game/Settings/Input.cs
 msgid "Keyboard mappings restored to defaults."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Vehicles\Catalog\Data.cs:240
+#: top_speed_net/TopSpeed.Shared/Vehicles/Catalog/Data.cs
 msgid "Lamborghini Aventador"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Language.cs:78
+#: top_speed_net/TopSpeed/Game/Settings/Language.cs
 #, csharp-format
 msgid "Language remains {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Language.cs:74
+#: top_speed_net/TopSpeed/Game/Settings/Language.cs
 #, csharp-format
 msgid "Language set to {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Game.cs:94
+#: top_speed_net/TopSpeed/Menu/Build/Options/Game.cs
 #, csharp-format
 msgid "Language: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:55
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
 #, csharp-format
 msgid "Lap percentage {0} percent"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:172
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "Lap statistics:"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:171
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "Lap summary:"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Systems\CoreRequests.cs:125
+#: top_speed_net/TopSpeed/Drive/Session/Systems/CoreRequests.cs
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
 #, csharp-format
 msgid "Lap {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:121
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
+#, csharp-format
+msgid "Lap {0}, approaching the finish"
+msgstr ""
+
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
+#, csharp-format
+msgid "Lap {0}, approaching turn {1}"
+msgstr ""
+
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
+#, csharp-format
+msgid "Lap {0}, in turn {1}"
+msgstr ""
+
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Last history item"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Check.cs:134
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Check.cs:152
+#: top_speed_net/TopSpeed/Game/Updates/Check.cs
 msgid "Latest changes"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Check.cs:103
+#: top_speed_net/TopSpeed/Game/Updates/Check.cs
 msgid "Latest changes are already being fetched."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Check.cs:122
+#: top_speed_net/TopSpeed/Game/Updates/Check.cs
 msgid "Latest changes request failed."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Updates\Service.cs:121
+#: top_speed_net/TopSpeed/Core/Updates/Service.cs
 #, csharp-format
 msgid "Latest changes request failed: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Updates\Service.cs:116
+#: top_speed_net/TopSpeed/Core/Updates/Service.cs
 msgid "Latest changes request timed out."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Session.cs:23
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Session.cs
 msgid "Leave server?"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Menu\LobbyAndControls.cs:44
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Menu/LobbyAndControls.cs
 msgid "Leave this game room"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\Room.cs:27
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/Room.cs
 msgid "Leave this game room?"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\Room.cs:60
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/Room.cs
 msgid "Leaving game room."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:70
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Left"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:36
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Left Alt"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:26
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Left Control"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:30
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Left Shift"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:77
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Left Windows"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:23
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Left bracket"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:199
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Left paddle 1"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:201
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Left paddle 2"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:179
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Left stick down"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:177
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Left stick left"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:178
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Left stick right"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:180
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Left stick up"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:185
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Left trigger"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Mapping\Handler\Keyboard.cs:34
+#: top_speed_net/TopSpeed/Input/Mapping/Handler/Keyboard.cs
 #, csharp-format
 msgid "Left {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Types.cs:31
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Types.cs
 #, csharp-format
 msgid "Line {0}: {1}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Live\Tx.cs:153
+#: top_speed_net/TopSpeed/Network/Live/Tx.cs
 msgid "Live streaming stopped because Opus encoding failed."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Live\Tx.cs:140
+#: top_speed_net/TopSpeed/Network/Live/Tx.cs
 msgid "Live streaming stopped because media decoding failed."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:186
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Load media file"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:195
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Load media folder"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\TrackPackages\Catalog.cs:81
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/TrackPackages/Catalog.cs
 msgid "Loading custom tracks from server."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:187
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Loads an audio file for streaming."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:196
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Loads an audio folder for streaming."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Panels\RadioPanel\Playback.cs:73
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Communicator\Runtime\MediaLocal.cs:254
+#: top_speed_net/TopSpeed/Drive/Panels/RadioPanel/Playback.cs
+#: top_speed_net/TopSpeed/Game/Multiplayer/Communicator/Runtime/MediaLocal.cs
 msgid "Loop mode off."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Panels\RadioPanel\Playback.cs:72
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Communicator\Runtime\MediaLocal.cs:253
+#: top_speed_net/TopSpeed/Drive/Panels/RadioPanel/Playback.cs
+#: top_speed_net/TopSpeed/Game/Multiplayer/Communicator/Runtime/MediaLocal.cs
 msgid "Loop mode on."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\TrackPackages\UploadProgress.cs:52
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Dialog.cs:65
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/TrackPackages/UploadProgress.cs
+#: top_speed_net/TopSpeed/Game/Updates/Dialog.cs
 msgid "MB"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Helpers.cs:42
+#: top_speed_net/TopSpeed/Menu/Build/Helpers.cs
 msgid ""
 "Main Menu. Use the view finder to move through the options. Press up or down "
 "to navigate. Press right or button 1 to select. Press left to back out of "
 "any menu."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Helpers.cs:43
+#: top_speed_net/TopSpeed/Menu/Build/Helpers.cs
 msgid ""
 "Main Menu. Use your arrow keys or the view finder to move through the "
 "options. Press ENTER or right or button 1 to select. Press ESCAPE or left to "
@@ -2107,18 +2115,18 @@ msgid ""
 "bottom of a menu."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Helpers.cs:41
+#: top_speed_net/TopSpeed/Menu/Build/Helpers.cs
 msgid ""
 "Main Menu. Use your arrow keys to navigate the options. Press ENTER to "
 "select. Press ESCAPE to back out of any menu. Pressing HOME or END will move "
 "you to the top or bottom of a menu."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Core.cs:156
+#: top_speed_net/TopSpeed/Menu/Build/Core.cs
 msgid "Main menu"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Helpers.cs:38
+#: top_speed_net/TopSpeed/Menu/Build/Helpers.cs
 msgid ""
 "Main menu. Swipe left or right to navigate the options. Swipe up to "
 "activate. Swipe down to go back. Swipe up with two fingers to move to the "
@@ -2126,1944 +2134,1922 @@ msgid ""
 "press repeats the current usage hint."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:87
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 msgid "Malformed line. Expected '[section]' or 'key = value'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Multiplayer.cs:13
+#: top_speed_net/TopSpeed/Menu/Build/Multiplayer.cs
 msgid "Manage saved servers"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Drive\Transmission.cs:31
+#: top_speed_net/TopSpeed/Menu/Build/Drive/Transmission.cs
 msgid "Manual"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Menu\Loadout.cs:30
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Menu/Loadout.cs
 msgid "Manual transmission"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Drive\Vehicles.cs:65
+#: top_speed_net/TopSpeed/Menu/Build/Drive/Vehicles.cs
 msgid "Manual transmission is required for this vehicle."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:49
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Map controller keys"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:48
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Map keyboard keys"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:50
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Map menu shortcuts"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Mapping\Handler\Core.cs:77
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Mapping\Handler\Keyboard.cs:52
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Mapping\Handler\Keyboard.cs:58
+#: top_speed_net/TopSpeed/Input/Mapping/Handler/Core.cs
+#: top_speed_net/TopSpeed/Input/Mapping/Handler/Keyboard.cs
 msgid "Mapping cancelled."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\VolumeShortcuts.cs:235
+#: top_speed_net/TopSpeed/Game/Settings/VolumeShortcuts.cs
 msgid "Master audio"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Volume.cs:15
+#: top_speed_net/TopSpeed/Menu/Build/Options/Volume.cs
 msgid "Master audio volume"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Create.cs:20
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Menus.cs:48
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Create.cs
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Menus.cs
 msgid "Maximum players allowed in this room"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Chat\HistoryText.cs:80
+#: top_speed_net/TopSpeed/Core/Multiplayer/Chat/HistoryText.cs
 #, csharp-format
 msgid "Maximum players changed to {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Speech.cs:75
+#: top_speed_net/TopSpeed/Menu/Build/Options/Speech.cs
 msgid ""
 "Measure your screen-reader speaking speed again so usage hints and delayed "
 "speech timings stay accurate."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Settings\Manager\Apply\RaceUi.cs:64
+#: top_speed_net/TopSpeed/Core/Settings/Manager/Apply/RaceUi.cs
 msgid "Menu sound preset was empty and was reset to default."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Game.cs:111
+#: top_speed_net/TopSpeed/Menu/Build/Options/Game.cs
 msgid "Menu sounds"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Game.cs:104
+#: top_speed_net/TopSpeed/Menu/Build/Options/Game.cs
 #, csharp-format
 msgid "Menu sounds: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Vehicles\Catalog\Data.cs:304
+#: top_speed_net/TopSpeed.Shared/Vehicles/Catalog/Data.cs
 msgid "Mercedes Sprinter"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Audio.cs:33
+#: top_speed_net/TopSpeed/Menu/Build/Options/Audio.cs
 msgid "Microphone input gain"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Vehicles\Catalog\Data.cs:148
+#: top_speed_net/TopSpeed.Shared/Vehicles/Catalog/Data.cs
 msgid "Mini Cooper S"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:19
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Minus"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Install.cs:28
+#: top_speed_net/TopSpeed/Game/Updates/Install.cs
 #, csharp-format
 msgid "Missing file: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Transmission\Types.cs:15
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Transmission\Types.cs:39
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Core\Readers\Bools.cs:12
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Core\Readers\FloatCsv.cs:11
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Core\Readers\Numbers.cs:12
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Core\Readers\Numbers.cs:44
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Core\Readers\Text.cs:12
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Core\Readers\Text.cs:34
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Transmission/Types.cs
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Core/Readers/Bools.cs
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Core/Readers/FloatCsv.cs
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Core/Readers/Numbers.cs
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Core/Readers/Text.cs
 #, csharp-format
 msgid "Missing required key '{0}' in section [{1}]."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Transmission\Modes.cs:33
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Transmission/Modes.cs
 msgid "Missing required section [transmission_atc] for supported type 'atc'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Transmission\Modes.cs:138
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Transmission/Modes.cs
 msgid "Missing required section [transmission_cvt] for supported type 'cvt'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Transmission\Modes.cs:85
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Transmission/Modes.cs
 msgid "Missing required section [transmission_dct] for supported type 'dct'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Core\Load\Sections.cs:76
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Core/Load/Sections.cs
 #, csharp-format
 msgid "Missing required section [{0}]."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Protocol\TrackPackages\Build\Assets.cs:82
+#: top_speed_net/TopSpeed.Shared/Protocol/TrackPackages/Build/Assets.cs
 #, csharp-format
 msgid "Missing sound asset file: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:39
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Moderate (0.75 seconds)"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\ModifierKeys.cs:117
+#: top_speed_net/TopSpeed/Input/ModifierKeys.cs
 msgid "Modifier"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Mapping\KeyMapManager.cs:97
+#: top_speed_net/TopSpeed/Input/Mapping/KeyMapManager.cs
 #, csharp-format
 msgid "Move or press the controller control for {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:114
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Moves to the first item in the selected multiplayer history category."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:122
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Moves to the last item in the selected multiplayer history category."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:106
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Moves to the next item in the selected multiplayer history category."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:138
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Moves to the next multiplayer history category."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:232
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Moves to the next track in the media playlist."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:98
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid ""
 "Moves to the previous item in the selected multiplayer history category."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:130
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Moves to the previous multiplayer history category."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:223
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Moves to the previous track in the media playlist."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Core.cs:150
+#: top_speed_net/TopSpeed/Menu/Build/Core.cs
 msgid "MultiPlayer game"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Multiplayer.cs:37
+#: top_speed_net/TopSpeed/Menu/Build/Multiplayer.cs
 msgid "Multiplayer lobby"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:302
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Multiplayer shortcuts"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Menu\Device.cs:36
+#: top_speed_net/TopSpeed/Game/Menu/Device.cs
 msgid "Multiple game controllers were detected. Select one controller to use."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:35
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Multiply"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\VolumeShortcuts.cs:243
+#: top_speed_net/TopSpeed/Game/Settings/VolumeShortcuts.cs
 msgid "Music"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Volume.cs:55
+#: top_speed_net/TopSpeed/Menu/Build/Options/Volume.cs
 msgid "Music volume"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Settings\Manager\Apply\Audio.cs:119
+#: top_speed_net/TopSpeed/Core/Settings/Manager/Apply/Audio.cs
 msgid "Music volume is not a valid number and was reset to default."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\TrackList.cs:36
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:118
+#: top_speed_net/TopSpeed/Core/TrackList.cs
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
 msgid "Netherlands"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\DisconnectMapping.cs:67
+#: top_speed_net/TopSpeed/Network/DisconnectMapping.cs
 msgid "Network is unreachable."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Live\Tx.cs:159
+#: top_speed_net/TopSpeed/Network/Live/Tx.cs
 msgid "Network send failed while sending live frame."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Live\Tx.cs:126
+#: top_speed_net/TopSpeed/Network/Live/Tx.cs
 msgid "Network send failed while sending live start."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Live\Tx.cs:183
+#: top_speed_net/TopSpeed/Network/Live/Tx.cs
 msgid "Network send failed while sending live stop."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Multiplayer\Session\Runtime\Audio.cs:69
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Multiplayer\Session\Systems\Sync.cs:94
+#: top_speed_net/TopSpeed/Drive/Multiplayer/Session/Runtime/Audio.cs
+#: top_speed_net/TopSpeed/Drive/Multiplayer/Session/Systems/Sync.cs
 msgid "Network send failed. Please check your connection."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Check.cs:199
+#: top_speed_net/TopSpeed/Game/Updates/Check.cs
 msgid "New version detected."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Core.cs:132
+#: top_speed_net/TopSpeed/Menu/Build/Core.cs
 msgid "Next chat category"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:137
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Next history category"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:105
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Next history item"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:231
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Next media track"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\VolumeShortcuts.cs:48
+#: top_speed_net/TopSpeed/Game/Settings/VolumeShortcuts.cs
 msgid "Next volume category"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Vehicles\Catalog\Data.cs:54
+#: top_speed_net/TopSpeed.Shared/Vehicles/Catalog/Data.cs
 msgid "Nissan GT-R Nismo"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Session.cs:28
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Input.cs:60
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Input.cs:88
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:287
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:325
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Session.cs
+#: top_speed_net/TopSpeed/Game/Settings/Input.cs
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "No"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Check.cs:143
+#: top_speed_net/TopSpeed/Game/Updates/Check.cs
 msgid "No changes are listed."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Communicator\Runtime\MediaLocal.cs:193
+#: top_speed_net/TopSpeed/Game/Multiplayer/Communicator/Runtime/MediaLocal.cs
 msgid "No communicator media loaded."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Mapping\Handler\Controller.cs:13
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Mapping\Handler\Core.cs:50
+#: top_speed_net/TopSpeed/Input/Mapping/Handler/Controller.cs
+#: top_speed_net/TopSpeed/Input/Mapping/Handler/Core.cs
 msgid "No controller detected."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Input.cs:14
+#: top_speed_net/TopSpeed/Game/Settings/Input.cs
 msgid "No controllers found"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Input.cs:15
+#: top_speed_net/TopSpeed/Game/Settings/Input.cs
 msgid "No controllers were found. The game has reverted to keyboard input."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\TrackPackages\Catalog.cs:119
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Drive\Tracks.cs:100
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/TrackPackages/Catalog.cs
+#: top_speed_net/TopSpeed/Menu/Build/Drive/Tracks.cs
 msgid "No custom tracks found."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Drive\Vehicles.cs:88
+#: top_speed_net/TopSpeed/Menu/Build/Drive/Vehicles.cs
 msgid "No custom vehicles found."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Panels\RadioPanel\Playback.cs:41
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Communicator\Runtime\MediaLocal.cs:222
+#: top_speed_net/TopSpeed/Drive/Panels/RadioPanel/Playback.cs
+#: top_speed_net/TopSpeed/Game/Multiplayer/Communicator/Runtime/MediaLocal.cs
 msgid "No folder playlist loaded."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Panels\RadioPanel\Playlist.cs:57
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Communicator\Runtime\MediaLocal.cs:444
+#: top_speed_net/TopSpeed/Drive/Panels/RadioPanel/Playlist.cs
+#: top_speed_net/TopSpeed/Game/Multiplayer/Communicator/Runtime/MediaLocal.cs
 msgid "No folder was selected."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Coordinator\RoomUi\RoomList.cs:31
+#: top_speed_net/TopSpeed/Core/Multiplayer/Coordinator/RoomUi/RoomList.cs
 msgid "No game rooms are currently available."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Browser.cs:46
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Browser.cs
 msgid "No game rooms found"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Language.cs:34
+#: top_speed_net/TopSpeed/Game/Settings/Language.cs
 msgid "No languages are available."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\RadioController\Load.cs:18
+#: top_speed_net/TopSpeed/Vehicles/RadioController/Load.cs
 msgid "No media file selected."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Chat\Buffers.cs:314
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Coordinator\Chat\Screens.cs:40
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Core.cs:57
+#: top_speed_net/TopSpeed/Core/Multiplayer/Chat/Buffers.cs
+#: top_speed_net/TopSpeed/Core/Multiplayer/Coordinator/Chat/Screens.cs
+#: top_speed_net/TopSpeed/Menu/Build/Core.cs
 msgid "No messages yet."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Draft.cs:121
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Draft.cs
 msgid "No option changes to apply."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\PitAreaWarning.cs:22
+#: top_speed_net/TopSpeed/Drive/PitAreaWarning.cs
 msgid "No pit area"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Menu\Players.cs:23
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Menu/Players.cs
 msgid "No players are currently in this game room."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Connect\Connector\Connect.cs:232
+#: top_speed_net/TopSpeed/Network/Connect/Connector/Connect.cs
 msgid ""
 "No protocol negotiation response from server. The server may be outdated or "
 "incompatible."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Panels\RadioPanel\Playback.cs:15
+#: top_speed_net/TopSpeed/Drive/Panels/RadioPanel/Playback.cs
 msgid "No radio media loaded."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Connect\Connector\Connect.cs:238
+#: top_speed_net/TopSpeed/Network/Connect/Connector/Connect.cs
 msgid "No response from server. The server may be offline or unreachable."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Connect\Connector\Connect.cs:23
+#: top_speed_net/TopSpeed/Network/Connect/Connector/Connect.cs
 msgid "No server address was provided."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Connection\Discovery.cs:36
+#: top_speed_net/TopSpeed/Core/Multiplayer/Connection/Discovery.cs
 msgid ""
 "No servers were found on the local network. You can enter an address "
 "manually."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:242
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "No shortcut group selected."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:161
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "No shortcuts in this group."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Panels\RadioPanel\Playlist.cs:69
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Communicator\Runtime\MediaLocal.cs:456
+#: top_speed_net/TopSpeed/Drive/Panels/RadioPanel/Playlist.cs
+#: top_speed_net/TopSpeed/Game/Multiplayer/Communicator/Runtime/MediaLocal.cs
 msgid "No supported audio files were found in the selected folder."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Check.cs:93
+#: top_speed_net/TopSpeed/Game/Updates/Check.cs
 msgid "No updates found"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\LoadoutExit.cs:28
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\LoadoutExit.cs:37
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/LoadoutExit.cs
 msgid "No, continue preparing"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Race\Runtime.cs:261
+#: top_speed_net/TopSpeed/Game/Multiplayer/Race/Runtime.cs
 msgid "No, continue racing"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\SavedServers\Delete.cs:20
+#: top_speed_net/TopSpeed/Core/Multiplayer/SavedServers/Delete.cs
 msgid "No, keep this server"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\Room.cs:32
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/Room.cs
 msgid "No, stay in this game room"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:92
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:102
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:112
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Normal"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:97
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "Not a clean run, but still recoverable."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Connection\Ping.cs:13
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Coordinator\Chat\Input.cs:15
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Coordinator\Chat\Input.cs:32
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Coordinator\Chat\Input.cs:58
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Coordinator\Chat\Input.cs:81
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\Loadout.cs:17
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\LoadoutExit.cs:53
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\LoadoutExit.cs:79
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\Room.cs:69
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\Room.cs:140
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\Room.cs:161
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\Room.cs:179
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Browser.cs:16
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Browser.cs:33
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Create.cs:66
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Create.cs:108
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Online.cs:19
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Draft.cs:70
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Draft.cs:134
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\TrackPackages\Catalog.cs:69
+#: top_speed_net/TopSpeed/Core/Multiplayer/Connection/Ping.cs
+#: top_speed_net/TopSpeed/Core/Multiplayer/Coordinator/Chat/Input.cs
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/Loadout.cs
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/LoadoutExit.cs
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/Room.cs
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Browser.cs
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Create.cs
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Online.cs
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Draft.cs
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/TrackPackages/Catalog.cs
 msgid "Not connected to a server."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\Room.cs:53
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/Room.cs
 msgid "Not connected to a server. Returning to main menu."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:105
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "Not ideal, but still salvageable."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Menu\Interfaces.cs:33
+#: top_speed_net/TopSpeed/Game/Menu/Interfaces.cs
 msgid "Not implemented yet."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:39
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Num Lock"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Drive.cs:57
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Drive.cs:105
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
 msgid "Number of computer players"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Menus.cs:39
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Drive.cs:52
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Menus.cs
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
 msgid "Number of laps"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Chat\HistoryText.cs:75
+#: top_speed_net/TopSpeed/Core/Multiplayer/Chat/HistoryText.cs
 #, csharp-format
 msgid "Number of laps changed to {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:61
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Numpad Comma"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:51
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Numpad Enter"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:44
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Numpad Equals"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Connection\Connect.cs:240
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Menu\Dialogs.cs:30
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Input.cs:19
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Input.cs:39
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Issues.cs:55
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Dialog.cs:53
+#: top_speed_net/TopSpeed/Core/Multiplayer/Connection/Connect.cs
+#: top_speed_net/TopSpeed/Game/Menu/Dialogs.cs
+#: top_speed_net/TopSpeed/Game/Settings/Input.cs
+#: top_speed_net/TopSpeed/Game/Settings/Issues.cs
+#: top_speed_net/TopSpeed/Game/Updates/Dialog.cs
 msgid "OK"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:36
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Off"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Menu\Calibration.cs:30
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Menu\Calibration.cs:34
+#: top_speed_net/TopSpeed/Game/Menu/Calibration.cs
 msgid "Ok"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:94
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "One crash is still too many, but it could be worse."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:80
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "One crash."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Coordinator\Core.cs:25
+#: top_speed_net/TopSpeed/Core/Multiplayer/Coordinator/Core.cs
 msgid "One-on-one without bots"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Multiplayer.cs:78
+#: top_speed_net/TopSpeed/Menu/Build/Multiplayer.cs
 msgid "Online players"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Volume.cs:64
+#: top_speed_net/TopSpeed/Menu/Build/Options/Volume.cs
 msgid "Online server event sounds"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\VolumeShortcuts.cs:244
+#: top_speed_net/TopSpeed/Game/Settings/VolumeShortcuts.cs
 msgid "Online server events"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\LoadoutExit.cs:59
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/LoadoutExit.cs
 msgid "Only the host can cancel the current game."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Draft.cs:19
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Draft.cs:76
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Menus.cs:23
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Draft.cs
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Menus.cs
 msgid "Only the host can change game options."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Menus.cs:79
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Menus.cs
 msgid "Only the host can change game rules."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\Room.cs:75
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/Room.cs
 msgid "Only the host can start the game."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Coordinator\RoomUi\Online.cs:22
+#: top_speed_net/TopSpeed/Core/Multiplayer/Coordinator/RoomUi/Online.cs
 msgid "Only you are connected right now."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:71
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Open global chat"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:79
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Open room chat"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:80
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Opens chat input for the current room chat when you are inside a room."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:72
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Opens chat input for the global multiplayer lobby chat."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:162
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Opens frequency input for the channel."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Menu\LobbyAndControls.cs:17
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Core.cs:151
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Multiplayer.cs:30
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Menu/LobbyAndControls.cs
+#: top_speed_net/TopSpeed/Menu/Build/Core.cs
+#: top_speed_net/TopSpeed/Menu/Build/Multiplayer.cs
 msgid "Options"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\VolumeShortcuts.cs:238
+#: top_speed_net/TopSpeed/Game/Settings/VolumeShortcuts.cs
 msgid "Other vehicles engine"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Volume.cs:30
+#: top_speed_net/TopSpeed/Menu/Build/Options/Volume.cs
 msgid "Other vehicles engine sounds"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Volume.cs:35
+#: top_speed_net/TopSpeed/Menu/Build/Options/Volume.cs
 msgid "Other vehicles event sounds"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\VolumeShortcuts.cs:239
+#: top_speed_net/TopSpeed/Game/Settings/VolumeShortcuts.cs
 msgid "Other vehicles events"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:10
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "Outstanding drive. You secured first position."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:35
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "Outstanding run! New personal record."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:162
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "POV 1 down"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:163
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "POV 1 left"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:161
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "POV 1 right"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:160
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "POV 1 up"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:166
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "POV 2 down"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:167
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "POV 2 left"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:165
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "POV 2 right"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:164
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "POV 2 up"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:74
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Page Down"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:69
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Page Up"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:162
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
 msgid "Panel"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:66
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Drive\Bind.cs:57
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
+#: top_speed_net/TopSpeed/Input/Drive/Bind.cs
 msgid "Pause"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Race\Runtime.cs:273
+#: top_speed_net/TopSpeed/Game/Multiplayer/Race/Runtime.cs
 msgid "Pause the game"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\DisconnectMapping.cs:82
+#: top_speed_net/TopSpeed/Network/DisconnectMapping.cs
 msgid "Peer session was not found on server."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\TrackPackages\UploadProgress.cs:30
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\TrackPackages\DownloadProgress.cs:43
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Dialog.cs:19
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/TrackPackages/UploadProgress.cs
+#: top_speed_net/TopSpeed/Game/Multiplayer/TrackPackages/DownloadProgress.cs
+#: top_speed_net/TopSpeed/Game/Updates/Dialog.cs
 #, csharp-format
 msgid "Percentage: {0}%"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Connection\Ping.cs:19
+#: top_speed_net/TopSpeed/Core/Multiplayer/Connection/Ping.cs
 msgid "Ping check already in progress."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Pit\PitStopMenu.cs:24
+#: top_speed_net/TopSpeed/Game/Drive/Pit/PitStopMenu.cs
 msgid "Pit stop"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Drive\Bind.cs:58
+#: top_speed_net/TopSpeed/Input/Drive/Bind.cs
 msgid "Pit this time"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Systems\PitStop.cs:237
+#: top_speed_net/TopSpeed/Drive/Session/Systems/PitStop.cs
 msgid "Pitting this time"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Game.cs:64
+#: top_speed_net/TopSpeed/Menu/Build/Options/Game.cs
 msgid "Play logo at startup"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:204
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Play or pause media"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultFmt.cs:21
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Connect\Connector\Helpers.cs:89
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultFmt.cs
+#: top_speed_net/TopSpeed/Network/Connect/Connector/Helpers.cs
 msgid "Player"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Coordinator\State\Rooms\Apply.cs:165
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Domain\Online\Map.cs:49
+#: top_speed_net/TopSpeed/Core/Multiplayer/Coordinator/State/Rooms/Apply.cs
+#: top_speed_net/TopSpeed/Core/Multiplayer/Domain/Online/Map.cs
 msgid "Player "
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Chat\HistoryText.cs:131
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Coordinator\State\Rooms\Store.cs:114
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Menu\Players.cs:30
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Online.cs:58
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Multiplayer\Session\Network\Participants.cs:132
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Multiplayer\Session\Runtime\Results.cs:31
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Systems\PlayerInfo.cs:172
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Single\Session\Format.cs:41
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\TimeTrial\Session\Format.cs:19
+#: top_speed_net/TopSpeed/Core/Multiplayer/Chat/HistoryText.cs
+#: top_speed_net/TopSpeed/Core/Multiplayer/Coordinator/State/Rooms/Store.cs
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Menu/Players.cs
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Online.cs
+#: top_speed_net/TopSpeed/Drive/Multiplayer/Session/Network/Participants.cs
+#: top_speed_net/TopSpeed/Drive/Multiplayer/Session/Runtime/Results.cs
+#: top_speed_net/TopSpeed/Drive/Session/Systems/PlayerInfo.cs
+#: top_speed_net/TopSpeed/Drive/Single/Session/Format.cs
+#: top_speed_net/TopSpeed/Drive/TimeTrial/Session/Format.cs
 #, csharp-format
 msgid "Player {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Multiplayer.cs:73
+#: top_speed_net/TopSpeed/Menu/Build/Multiplayer.cs
 msgid "Players in room"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Connection\Connect.cs:17
+#: top_speed_net/TopSpeed/Core/Multiplayer/Connection/Connect.cs
 msgid "Please enter a server address."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Install.cs:102
+#: top_speed_net/TopSpeed/Game/Updates/Install.cs
 msgid "Please restart the game and try again."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Connection\Discovery.cs:23
+#: top_speed_net/TopSpeed/Core/Multiplayer/Connection/Discovery.cs
 msgid "Please wait. Scanning for servers on the local network."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\TrackList.cs:52
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:142
+#: top_speed_net/TopSpeed/Core/TrackList.cs
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
 msgid "Polar escape"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Vehicles\Catalog\Data.cs:86
+#: top_speed_net/TopSpeed.Shared/Vehicles/Catalog/Data.cs
 msgid "Porsche 911 GT3 RS"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\TrackList.cs:37
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:120
+#: top_speed_net/TopSpeed/Core/TrackList.cs
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
 msgid "Portugal"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Online.cs:65
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Online.cs
 msgid "Preparing to race"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Menus.cs:36
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Helpers.cs:97
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Menus.cs
+#: top_speed_net/TopSpeed/Menu/Build/Helpers.cs
 msgid "Press ENTER to change."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Create.cs:53
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Create.cs
 msgid "Press ENTER to enter a room name."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Helpers.cs:110
+#: top_speed_net/TopSpeed/Menu/Build/Helpers.cs
 msgid "Press ENTER to select."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Helpers.cs:123
+#: top_speed_net/TopSpeed/Menu/Build/Helpers.cs
 msgid "Press ENTER to start."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Helpers.cs:84
+#: top_speed_net/TopSpeed/Menu/Build/Helpers.cs
 msgid "Press ENTER to toggle."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:46
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Press LEFT or RIGHT to change."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Dialog.cs:40
+#: top_speed_net/TopSpeed/Game/Updates/Dialog.cs
 msgid "Press OK to close the game and install the update."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Items\MenuItem.cs:124
+#: top_speed_net/TopSpeed/Menu/Items/MenuItem.cs
 msgid "Press right arrow to view."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Mapping\KeyMapManager.cs:96
+#: top_speed_net/TopSpeed/Input/Mapping/KeyMapManager.cs
 #, csharp-format
 msgid "Press the new key for {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Shortcuts\Mapping.cs:63
+#: top_speed_net/TopSpeed/Shortcuts/Mapping.cs
 #, csharp-format
 msgid "Press the new shortcut for {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Core.cs:125
+#: top_speed_net/TopSpeed/Menu/Build/Core.cs
 msgid "Previous chat category"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:129
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Previous history category"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:97
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Previous history item"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:222
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Previous media track"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\VolumeShortcuts.cs:57
+#: top_speed_net/TopSpeed/Game/Settings/VolumeShortcuts.cs
 msgid "Previous volume category"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:63
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Print Screen"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:33
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Progressive keyboard input"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:93
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 #, csharp-format
 msgid "Property '{0}' is outside any section."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Connect\Connector\Connect.cs:224
+#: top_speed_net/TopSpeed/Network/Connect/Connector/Connect.cs
 #, csharp-format
 msgid ""
 "Protocol packet version mismatch. Server uses packet version {0}, client "
 "expects {1}. Update your client or server."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Menu\About.cs:19
+#: top_speed_net/TopSpeed/Game/Menu/About.cs
 #, csharp-format
 msgid "Protocol version: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Validation\Tires.cs:28
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Validation/Tires.cs
 msgid ""
 "Provide tire_circumference or all of tire_width, tire_aspect, and tire_rim."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Proxy.cs:42
+#: top_speed_net/TopSpeed/Game/Settings/Proxy.cs
 msgid "Proxy URL cannot be empty while proxy is enabled."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Proxy.cs:50
+#: top_speed_net/TopSpeed/Game/Settings/Proxy.cs
 msgid "Proxy URL must be a valid HTTP or HTTPS URL."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Proxy.cs:58
+#: top_speed_net/TopSpeed/Game/Settings/Proxy.cs
 msgid "Proxy URL saved."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Game.cs:135
+#: top_speed_net/TopSpeed/Menu/Build/Options/Game.cs
 msgid "Proxy URL, currently empty."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Game.cs:137
+#: top_speed_net/TopSpeed/Menu/Build/Options/Game.cs
 #, csharp-format
 msgid "Proxy URL, currently set to {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:177
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Push to talk"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Dialogs\Question.cs:91
+#: top_speed_net/TopSpeed/Menu/Dialogs/Question.cs
 msgid "Question"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Core.cs:147
+#: top_speed_net/TopSpeed/Menu/Build/Core.cs
 msgid "Quick start"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Setup.cs:175
+#: top_speed_net/TopSpeed/Game/Drive/Setup.cs
 msgid "Quick start."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\LoadoutExit.cs:32
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/LoadoutExit.cs
 msgid "Quit race preparation?"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Race\Runtime.cs:256
+#: top_speed_net/TopSpeed/Game/Multiplayer/Race/Runtime.cs
 msgid "Quit race?"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Race\Runtime.cs:278
+#: top_speed_net/TopSpeed/Game/Multiplayer/Race/Runtime.cs
 msgid "Quit the race"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:134
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "RX minus"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:135
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "RX plus"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:136
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "RY minus"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:137
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "RY plus"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:138
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "RZ minus"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:139
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "RZ plus"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\Room.cs:127
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Setup.cs:96
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/Room.cs
+#: top_speed_net/TopSpeed/Game/Drive/Setup.cs
 msgid "Race anyway"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:16
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "Race complete."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Chat\HistoryText.cs:116
+#: top_speed_net/TopSpeed/Core/Multiplayer/Chat/HistoryText.cs
 msgid "Race paused."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:49
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
 #, csharp-format
 msgid "Race percentage {0} percent"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Chat\HistoryText.cs:101
+#: top_speed_net/TopSpeed/Core/Multiplayer/Chat/HistoryText.cs
 msgid "Race preparation started."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Chat\HistoryText.cs:104
+#: top_speed_net/TopSpeed/Core/Multiplayer/Chat/HistoryText.cs
 msgid "Race preparation was cancelled."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Chat\HistoryText.cs:119
+#: top_speed_net/TopSpeed/Core/Multiplayer/Chat/HistoryText.cs
 msgid "Race resumed."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Main.cs:35
+#: top_speed_net/TopSpeed/Menu/Build/Options/Main.cs
 msgid "Race settings"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Chat\HistoryText.cs:107
+#: top_speed_net/TopSpeed/Core/Multiplayer/Chat/HistoryText.cs
 msgid "Race started."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Systems\CoreRequests.cs:165
+#: top_speed_net/TopSpeed/Drive/Session/Systems/CoreRequests.cs
 #, csharp-format
 msgid "Race time {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\TrackSelection.cs:46
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Drive\Tracks.cs:15
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/TrackSelection.cs
+#: top_speed_net/TopSpeed/Menu/Build/Drive/Tracks.cs
 msgid "Race track"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Coordinator\Core.cs:23
+#: top_speed_net/TopSpeed/Core/Multiplayer/Coordinator/Core.cs
 msgid "Race with bots"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Coordinator\Core.cs:24
+#: top_speed_net/TopSpeed/Core/Multiplayer/Coordinator/Core.cs
 msgid "Race without bots"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Backends\Sdl\Discovery\Display.cs:41
+#: top_speed_net/TopSpeed/Input/Backends/Sdl/Discovery/Display.cs
 msgid "Racing wheel"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Panels\RadioPanel\Core.cs:68
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\VolumeShortcuts.cs:241
+#: top_speed_net/TopSpeed/Drive/Panels/RadioPanel/Core.cs
+#: top_speed_net/TopSpeed/Game/Settings/VolumeShortcuts.cs
 msgid "Radio"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Volume.cs:45
+#: top_speed_net/TopSpeed/Menu/Build/Options/Volume.cs
 msgid "Radio volume"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\TrackList.cs:50
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:138
+#: top_speed_net/TopSpeed/Core/TrackList.cs
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
 msgid "Rally desert"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\TrackList.cs:46
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:130
+#: top_speed_net/TopSpeed/Core/TrackList.cs
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
 msgid "Rally hills"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\TrackSelection.cs:56
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\TrackSelection.cs:71
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\TrackPackages\Catalog.cs:101
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Drive\Tracks.cs:18
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Drive\Tracks.cs:35
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Drive\Tracks.cs:64
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Drive\Transmission.cs:32
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Drive\Vehicles.cs:23
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Drive\Vehicles.cs:53
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/TrackSelection.cs
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/TrackPackages/Catalog.cs
+#: top_speed_net/TopSpeed/Menu/Build/Drive/Tracks.cs
+#: top_speed_net/TopSpeed/Menu/Build/Drive/Transmission.cs
+#: top_speed_net/TopSpeed/Menu/Build/Drive/Vehicles.cs
 msgid "Random"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Menu\Loadout.cs:31
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Menu/Loadout.cs
 msgid "Random transmission mode"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Menu\Loadout.cs:21
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Menu/Loadout.cs
 msgid "Random vehicle"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\Loadout.cs:43
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/Loadout.cs
 msgid "Ready. Waiting for other players."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Speech.cs:72
+#: top_speed_net/TopSpeed/Menu/Build/Options/Speech.cs
 msgid "Recalibrate screen reader rate"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\RadioController\Load.cs:91
+#: top_speed_net/TopSpeed/Vehicles/RadioController/Load.cs
 msgid "Received media is empty."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Reconnect.cs:41
+#: top_speed_net/TopSpeed/Game/Multiplayer/Reconnect.cs
 msgid "Reconnected to server."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Connection\Reconnector.cs:120
+#: top_speed_net/TopSpeed/Game/Multiplayer/Connection/Reconnector.cs
 msgid "Reconnection canceled."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Connection\Reconnector.cs:95
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Connection\Reconnector.cs:132
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Reconnect.cs:46
+#: top_speed_net/TopSpeed/Game/Multiplayer/Connection/Reconnector.cs
+#: top_speed_net/TopSpeed/Game/Multiplayer/Reconnect.cs
 msgid "Reconnection failed."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Connection\Reconnector.cs:128
+#: top_speed_net/TopSpeed/Game/Multiplayer/Connection/Reconnector.cs
 #, csharp-format
 msgid "Reconnection failed: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\Room.cs:48
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/Room.cs
 msgid "Reconnection is in progress. Disconnecting now."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Pit\PitStopMenu.cs:18
+#: top_speed_net/TopSpeed/Game/Drive/Pit/PitStopMenu.cs
 msgid "Refuel"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Menu\LobbyAndControls.cs:41
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Menu/LobbyAndControls.cs
 msgid "Remove a bot"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Drive\Bind.cs:52
+#: top_speed_net/TopSpeed/Input/Drive/Bind.cs
 msgid "Report distance"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Drive\Bind.cs:54
+#: top_speed_net/TopSpeed/Input/Drive/Bind.cs
 msgid "Report fuel"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Drive\Bind.cs:53
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
+msgid "Report lap and turn instead of race percentage"
+msgstr ""
+
+#: top_speed_net/TopSpeed/Input/Drive/Bind.cs
 msgid "Report speed"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Drive\Bind.cs:55
+#: top_speed_net/TopSpeed/Input/Drive/Bind.cs
 msgid "Report tire state"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Drive\Bind.cs:56
+#: top_speed_net/TopSpeed/Input/Drive/Bind.cs
 msgid "Report track name"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Drive\Bind.cs:45
+#: top_speed_net/TopSpeed/Input/Drive/Bind.cs
 msgid "Request position information"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Main.cs:46
+#: top_speed_net/TopSpeed/Menu/Build/Options/Main.cs
 msgid "Reset all configurable settings back to their default values."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:193
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Reset all controller mappings"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:188
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Reset all keyboard mappings"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:214
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Reset all menu shortcuts to defaults"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:283
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Reset all menu shortcuts?"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Input.cs:72
+#: top_speed_net/TopSpeed/Game/Settings/Input.cs
 msgid "Reset controller mappings"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Input.cs:71
+#: top_speed_net/TopSpeed/Game/Settings/Input.cs
 msgid "Reset keyboard mappings"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:267
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Reset shortcuts in this menu"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:319
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Reset shortcuts in this menu?"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:196
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Restore all controller bindings to their default values."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:191
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Restore all keyboard bindings to their default values."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Input.cs:50
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Main.cs:43
+#: top_speed_net/TopSpeed/Game/Settings/Input.cs
+#: top_speed_net/TopSpeed/Menu/Build/Options/Main.cs
 msgid "Restore default settings"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:217
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Restore every menu shortcut binding to its default value."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:270
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Restore only the shortcuts in this menu to their default values."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Race\Runtime.cs:272
+#: top_speed_net/TopSpeed/Game/Multiplayer/Race/Runtime.cs
 msgid "Resume the game"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\LoadoutExit.cs:97
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/LoadoutExit.cs
 msgid "Returned to room controls."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Connection\Connect.cs:187
+#: top_speed_net/TopSpeed/Core/Multiplayer/Connection/Connect.cs
 msgid "Review these details before connecting."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\TrackList.cs:49
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:136
+#: top_speed_net/TopSpeed/Core/TrackList.cs
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
 msgid "Ride airport"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:71
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Right"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:64
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Right Alt"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:52
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Right Control"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:34
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Right Shift"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:78
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Right Windows"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:24
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Right bracket"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:200
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Right paddle 1"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:202
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Right paddle 2"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:183
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Right stick down"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:181
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Right stick left"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:182
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Right stick right"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:184
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Right stick up"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:186
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Right trigger"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Mapping\Handler\Keyboard.cs:35
+#: top_speed_net/TopSpeed/Input/Mapping/Handler/Keyboard.cs
 #, csharp-format
 msgid "Right {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:320
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Multiplayer.cs:67
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
+#: top_speed_net/TopSpeed/Menu/Build/Multiplayer.cs
 msgid "Room controls"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Chat\HistoryText.cs:66
+#: top_speed_net/TopSpeed/Core/Multiplayer/Chat/HistoryText.cs
 msgid "Room host changed."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Create.cs:98
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Create.cs
 #, csharp-format
 msgid "Room name set to {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Create.cs:45
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Create.cs
 msgid "Room name, currently automatic"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Create.cs:47
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Create.cs
 #, csharp-format
 msgid "Room name, currently {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Draft.cs:120
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Draft.cs
 msgid "Room options updated."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Chat\HistoryText.cs:62
+#: top_speed_net/TopSpeed/Core/Multiplayer/Chat/HistoryText.cs
 #, csharp-format
 msgid "Room removed: {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:44
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "Run complete. Better luck on the next attempt."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:43
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "Run finished. Previous best remains unbeaten."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\TrackList.cs:51
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:140
+#: top_speed_net/TopSpeed/Core/TrackList.cs
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
 msgid "Rush hour"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\TrackList.cs:38
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:122
+#: top_speed_net/TopSpeed/Core/TrackList.cs
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
 msgid "Russia"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\SavedServers\Form.cs:66
+#: top_speed_net/TopSpeed/Core/Multiplayer/SavedServers/Form.cs
 msgid "Save changes"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\SavedServers\Form.cs:63
+#: top_speed_net/TopSpeed/Core/Multiplayer/SavedServers/Form.cs
 msgid "Save changes before closing?"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\SavedServers\Form.cs:47
+#: top_speed_net/TopSpeed/Core/Multiplayer/SavedServers/Form.cs
 msgid "Save server"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\SavedServers\Form.cs:46
+#: top_speed_net/TopSpeed/Core/Multiplayer/SavedServers/Form.cs
 msgid "Save server changes"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\SavedServers\Menu.cs:71
+#: top_speed_net/TopSpeed/Core/Multiplayer/SavedServers/Menu.cs
 msgid "Saved server host is empty."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Settings\Manager\Apply\Speech.cs:46
+#: top_speed_net/TopSpeed/Core/Settings/Manager/Apply/Speech.cs
 msgid "Screen reader rate is not a valid number and was reset to default."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Core\State.cs:118
+#: top_speed_net/TopSpeed/Game/Core/State.cs
 msgid ""
 "Screen-reader calibration. You'll be presented with a short piece of text on "
 "the next screen. Press ENTER when your screen-reader finishes speaking it."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Core\State.cs:119
+#: top_speed_net/TopSpeed/Game/Core/State.cs
 msgid ""
 "Screen-reader calibration. You'll be presented with a short piece of text on "
 "the next screen. Swipe up when your screen-reader finishes speaking it."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:40
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Scroll Lock"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:54
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 #, csharp-format
 msgid "Section '{0}' requires an id."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Torque\TorqueCurve.cs:108
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Torque/TorqueCurve.cs
 msgid ""
 "Section [torque_curve] must define at least two RPM points, or a preset with "
 "enough points."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Transmission\Modes.cs:21
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Transmission/Modes.cs
 msgid ""
 "Section [transmission_atc] is unused because supported_types does not "
 "include 'atc'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Transmission\Modes.cs:126
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Transmission/Modes.cs
 msgid ""
 "Section [transmission_cvt] is unused because supported_types does not "
 "include 'cvt'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Transmission\Modes.cs:73
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Transmission/Modes.cs
 msgid ""
 "Section [transmission_dct] is unused because supported_types does not "
 "include 'dct'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:190
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 #, csharp-format
 msgid ""
 "Segment '{0}' references room '{1}', but no matching [room:{1}] section or "
 "preset exists."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:203
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 #, csharp-format
 msgid ""
 "Segment '{0}' references sound source '{1}', but no matching [sound:{1}] "
 "section exists."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:215
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 #, csharp-format
 msgid ""
 "Segment '{0}' references weather profile '{1}', but no matching [weather:"
 "{1}] section exists."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:46
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Segment length '{0}' is below minimum {1} and will be clamped."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:87
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 msgid "Segment room id cannot be empty."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:100
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 msgid "Segment sound source list cannot be empty."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:68
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 msgid "Segment weather profile id cannot be empty."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Drive\Tracks.cs:41
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Multiplayer.cs:108
+#: top_speed_net/TopSpeed/Menu/Build/Drive/Tracks.cs
+#: top_speed_net/TopSpeed/Menu/Build/Multiplayer.cs
 msgid "Select a custom track"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Drive\Vehicles.cs:29
+#: top_speed_net/TopSpeed/Menu/Build/Drive/Vehicles.cs
 msgid "Select a custom vehicle"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Window\Eto\FileDialogService.cs:27
-#: D:\top_speed\top_speed_net\TopSpeed\Window\WinForms\FileDialogService.cs:25
+#: top_speed_net/TopSpeed/Window/Eto/FileDialogService.cs
+#: top_speed_net/TopSpeed/Window/WinForms/FileDialogService.cs
 msgid "Select a media file"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Window\Eto\FileDialogService.cs:49
-#: D:\top_speed\top_speed_net\TopSpeed\Window\WinForms\FileDialogService.cs:50
+#: top_speed_net/TopSpeed/Window/Eto/FileDialogService.cs
+#: top_speed_net/TopSpeed/Window/WinForms/FileDialogService.cs
 msgid "Select a media folder"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Drive\Tracks.cs:36
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Multiplayer.cs:98
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Multiplayer.cs:103
+#: top_speed_net/TopSpeed/Menu/Build/Drive/Tracks.cs
+#: top_speed_net/TopSpeed/Menu/Build/Multiplayer.cs
 msgid "Select a track"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Drive\Vehicles.cs:24
+#: top_speed_net/TopSpeed/Menu/Build/Drive/Vehicles.cs
 msgid "Select a vehicle"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:25
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 #, csharp-format
 msgid "Select device: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:76
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Select input device"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Game.cs:116
+#: top_speed_net/TopSpeed/Menu/Build/Options/Game.cs
 msgid "Select the menu sound preset."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Audio.cs:31
+#: top_speed_net/TopSpeed/Menu/Build/Options/Audio.cs
 msgid "Select the microphone used for communicator voice chat in multiplayer."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Menus.cs:53
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Menus.cs
 msgid ""
 "Select the player capacity for this room. The host can start with fewer "
 "players than the specified maximum players, so this is not a hard "
 "requirement."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Drive\Transmission.cs:34
+#: top_speed_net/TopSpeed/Menu/Build/Drive/Transmission.cs
 msgid "Select transmission mode"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Audio.cs:62
+#: top_speed_net/TopSpeed/Game/Settings/Audio.cs
 msgid "Select voice input device"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Speech.cs:121
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Speech.cs:133
+#: top_speed_net/TopSpeed/Menu/Build/Options/Speech.cs
 msgid "Select which voice the current speech backend should use."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Install.cs:90
+#: top_speed_net/TopSpeed/Game/Updates/Install.cs
 #, csharp-format
 msgid "Selected file: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:27
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Semicolon"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:143
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "Seriously? You could have done much better than that."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\SavedServers\Form.cs:100
+#: top_speed_net/TopSpeed/Core/Multiplayer/SavedServers/Form.cs
 msgid "Server IP or host cannot be empty."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\SavedServers\Form.cs:24
+#: top_speed_net/TopSpeed/Core/Multiplayer/SavedServers/Form.cs
 msgid "Server IP or host, currently empty."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\SavedServers\Form.cs:26
+#: top_speed_net/TopSpeed/Core/Multiplayer/SavedServers/Form.cs
 #, csharp-format
 msgid "Server IP or host, currently set to {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\SavedServers\Delete.cs:53
+#: top_speed_net/TopSpeed/Core/Multiplayer/SavedServers/Delete.cs
 msgid "Server deleted."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Multiplayer.cs:48
+#: top_speed_net/TopSpeed/Menu/Build/Multiplayer.cs
 msgid "Server details"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\SavedServers\Form.cs:17
+#: top_speed_net/TopSpeed/Core/Multiplayer/SavedServers/Form.cs
 msgid "Server name, currently empty."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\SavedServers\Form.cs:19
+#: top_speed_net/TopSpeed/Core/Multiplayer/SavedServers/Form.cs
 #, csharp-format
 msgid "Server name, currently set to {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\SavedServers\Form.cs:34
+#: top_speed_net/TopSpeed/Core/Multiplayer/SavedServers/Form.cs
 msgid "Server port, currently empty."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\SavedServers\Form.cs:32
+#: top_speed_net/TopSpeed/Core/Multiplayer/SavedServers/Form.cs
 #, csharp-format
 msgid "Server port, currently set to {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\SavedServers\Form.cs:118
+#: top_speed_net/TopSpeed/Core/Multiplayer/SavedServers/Form.cs
 msgid "Server saved."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Main.cs:39
+#: top_speed_net/TopSpeed/Menu/Build/Options/Main.cs
 msgid "Server settings"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Connection\Connect.cs:181
+#: top_speed_net/TopSpeed/Core/Multiplayer/Connection/Connect.cs
 #, csharp-format
 msgid "Server supported protocol versions: {0} to {1}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Coordinator\Communicator.cs:37
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:161
+#: top_speed_net/TopSpeed/Core/Multiplayer/Coordinator/Communicator.cs
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Set frequency"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Main.cs:38
+#: top_speed_net/TopSpeed/Menu/Build/Options/Main.cs
 msgid ""
 "Set race defaults such as copilot callouts, curve announcements, automatic "
 "information, laps, computer opponents, and difficulty."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Drive.cs:38
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
 msgid "Sets how early speed dependent curve announcements are spoken."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Drive.cs:61
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
 msgid "Sets how many computer-controlled cars will race against you."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Drive.cs:56
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
 msgid ""
 "Sets how many laps the race will be for single race, time trial, and "
 "multiplayer."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:141
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid ""
 "Sets how much small steering movement is ignored around center. Default is 1 "
 "degree."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Settings\Manager\ParseErrors.cs:23
+#: top_speed_net/TopSpeed/Core/Settings/Manager/ParseErrors.cs
 #, csharp-format
 msgid ""
 "Settings file '{0}' could not be read as valid JSON. Defaults were used. "
 "Details: {1}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Settings\Manager\Load.cs:88
+#: top_speed_net/TopSpeed/Core/Settings/Manager/Load.cs
 #, csharp-format
 msgid "Settings file '{0}' is empty or invalid. Defaults were used."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Settings\Manager\Load.cs:25
+#: top_speed_net/TopSpeed/Core/Settings/Manager/Load.cs
 #, csharp-format
 msgid "Settings file '{0}' was not found. Default settings were created."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Issues.cs:43
+#: top_speed_net/TopSpeed/Game/Settings/Issues.cs
 msgid "Settings file parse error"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Issues.cs:44
+#: top_speed_net/TopSpeed/Game/Settings/Issues.cs
 msgid "Settings notice"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Menu\Wizard.cs:11
+#: top_speed_net/TopSpeed/Game/Menu/Wizard.cs
 msgid "Setup wizard."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Core.cs:140
+#: top_speed_net/TopSpeed/Menu/Build/Core.cs
 msgid "Shared lobby chat"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\ModifierKeys.cs:114
+#: top_speed_net/TopSpeed/Input/ModifierKeys.cs
 msgid "Shift"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Drive\Bind.cs:43
+#: top_speed_net/TopSpeed/Input/Drive/Bind.cs
 msgid "Shift gear down"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Drive\Bind.cs:42
+#: top_speed_net/TopSpeed/Input/Drive/Bind.cs
 msgid "Shift gear up"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Settings\Manager\Apply\Input.cs:149
+#: top_speed_net/TopSpeed/Core/Settings/Manager/Apply/Input.cs
 msgid "Shortcut binding id is missing and was ignored."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Shortcuts\Mapping.cs:70
+#: top_speed_net/TopSpeed/Shortcuts/Mapping.cs
 msgid "Shortcut mapping cancelled."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:365
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 #, csharp-format
 msgid "Shortcuts in {0} were reset to defaults."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Panels\RadioPanel\Playback.cs:64
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Panels\RadioPanel\Selection.cs:88
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Communicator\Runtime\MediaLocal.cs:143
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Communicator\Runtime\MediaLocal.cs:245
+#: top_speed_net/TopSpeed/Drive/Panels/RadioPanel/Playback.cs
+#: top_speed_net/TopSpeed/Drive/Panels/RadioPanel/Selection.cs
+#: top_speed_net/TopSpeed/Game/Multiplayer/Communicator/Runtime/MediaLocal.cs
 msgid "Shuffle mode off."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Panels\RadioPanel\Playback.cs:63
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Panels\RadioPanel\Selection.cs:87
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Communicator\Runtime\MediaLocal.cs:142
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Communicator\Runtime\MediaLocal.cs:244
+#: top_speed_net/TopSpeed/Drive/Panels/RadioPanel/Playback.cs
+#: top_speed_net/TopSpeed/Drive/Panels/RadioPanel/Selection.cs
+#: top_speed_net/TopSpeed/Game/Multiplayer/Communicator/Runtime/MediaLocal.cs
 msgid "Shuffle mode on."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Core.cs:149
+#: top_speed_net/TopSpeed/Menu/Build/Core.cs
 msgid "Single race"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Drive.cs:62
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
 msgid "Single race difficulty"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Setup.cs:176
+#: top_speed_net/TopSpeed/Game/Drive/Setup.cs
 msgid "Single race."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:33
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Slash"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:140
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Slider 1 minus"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:141
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Slider 1 plus"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:142
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Slider 2 minus"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:143
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Slider 2 plus"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:40
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Slowest (1.00 second)"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Drive\Tracks.cs:95
+#: top_speed_net/TopSpeed/Menu/Build/Drive/Tracks.cs
 msgid "Some custom track files are invalid and were skipped."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Drive\Tracks.cs:113
+#: top_speed_net/TopSpeed/Menu/Build/Drive/Tracks.cs
 msgid ""
 "Some custom track files reported issues. Tracks with errors were skipped; "
 "tracks with warnings still loaded."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Drive\Vehicles.cs:83
+#: top_speed_net/TopSpeed/Menu/Build/Drive/Vehicles.cs
 msgid "Some custom vehicle files are invalid and were skipped."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Drive\Vehicles.cs:100
+#: top_speed_net/TopSpeed/Menu/Build/Drive/Vehicles.cs
 msgid ""
 "Some custom vehicle files reported issues. Vehicles with errors were "
 "skipped; vehicles with warnings still loaded."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Issues.cs:47
+#: top_speed_net/TopSpeed/Game/Settings/Issues.cs
 msgid "Some settings were missing or invalid. Review these details."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:237
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 #, csharp-format
 msgid ""
 "Sound '{0}' references end_area '{1}', but no matching segment id exists."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:226
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 #, csharp-format
 msgid ""
 "Sound '{0}' references start_area '{1}', but no matching segment id exists."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Protocol\TrackPackages\Build\Assets.cs:76
+#: top_speed_net/TopSpeed.Shared/Protocol/TrackPackages/Build/Assets.cs
 #, csharp-format
 msgid "Sound asset path escapes the track folder: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:234
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid ""
 "Sound key '{0}' contains invalid path '{1}'. Paths must be track-relative."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:220
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid ""
 "Sound key '{0}' must be a track-relative path and cannot escape the track "
 "folder."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:228
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:244
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Sound list for '{0}' cannot be empty."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:37
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Space"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\TrackList.cs:39
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:124
+#: top_speed_net/TopSpeed/Core/TrackList.cs
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
 msgid "Spain"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:89
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Speaks currently active game rules for the current game room."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:170
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Speaks the currently selected channel frequency."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:64
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Speaks your current ping while you are in multiplayer menus."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Main.cs:16
+#: top_speed_net/TopSpeed/Menu/Build/Options/Main.cs
 msgid "Speech"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Speech.cs:45
+#: top_speed_net/TopSpeed/Menu/Build/Options/Speech.cs
 msgid "Speech backend"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Speech.cs:30
+#: top_speed_net/TopSpeed/Menu/Build/Options/Speech.cs
 #, csharp-format
 msgid "Speech backend: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Speech.cs:98
+#: top_speed_net/TopSpeed/Menu/Build/Options/Speech.cs
 msgid "Speech mode"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Speech.cs:139
+#: top_speed_net/TopSpeed/Menu/Build/Options/Speech.cs
 msgid "Speech rate"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Drive.cs:33
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
 msgid "Speed dependent curve announcement lead time"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Drive\Bind.cs:51
+#: top_speed_net/TopSpeed/Input/Drive/Bind.cs
 msgid "Start the engine"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Menu\LobbyAndControls.cs:35
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Menu/LobbyAndControls.cs
 msgid "Start the game"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Drive\Bind.cs:37
+#: top_speed_net/TopSpeed/Input/Drive/Bind.cs
 msgid "Steer left"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Drive\Bind.cs:38
+#: top_speed_net/TopSpeed/Input/Drive/Bind.cs
 msgid "Steer right"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:118
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Steering dead zone"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Audio.cs:17
+#: top_speed_net/TopSpeed/Menu/Build/Options/Audio.cs
 msgid "Stereo widening for own car"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:49
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Stop"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Race\Runtime.cs:277
+#: top_speed_net/TopSpeed/Game/Multiplayer/Race/Runtime.cs
 msgid "Stop the game"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\TrackSelection.cs:47
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Drive\Tracks.cs:16
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/TrackSelection.cs
+#: top_speed_net/TopSpeed/Menu/Build/Drive/Tracks.cs
 msgid "Street adventure"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:41
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Subtract"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:55
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "Summary of this run and your previous best:"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:50
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "Summary of your latest time trial run:"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Volume.cs:40
+#: top_speed_net/TopSpeed/Menu/Build/Options/Volume.cs
 msgid "Surface loop sounds"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\VolumeShortcuts.cs:240
+#: top_speed_net/TopSpeed/Game/Settings/VolumeShortcuts.cs
 msgid "Surface loops"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\TrackList.cs:40
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:126
+#: top_speed_net/TopSpeed/Core/TrackList.cs
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
 msgid "Sweden"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Create.cs:27
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Create.cs:41
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Menus.cs:55
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Helpers.cs:137
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:47
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Create.cs
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Menus.cs
+#: top_speed_net/TopSpeed/Menu/Build/Helpers.cs
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Swipe left or right with two fingers to change."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Items\MenuItem.cs:125
+#: top_speed_net/TopSpeed/Menu/Items/MenuItem.cs
 msgid "Swipe left or right with two fingers to view."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Drive.cs:40
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
 msgid ""
 "Swipe up or down with two fingers to change by 1.0 second, swipe left or "
 "right with two fingers to change by 0.1 seconds, and swipe up or down with "
 "three fingers for maximum or minimum."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Menus.cs:46
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Helpers.cs:150
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Menus.cs
+#: top_speed_net/TopSpeed/Menu/Build/Helpers.cs
 msgid ""
 "Swipe up or down with two fingers to change by 10, swipe left or right with "
 "two fingers to change by 1, and swipe up or down with three fingers for "
 "maximum or minimum."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Menus.cs:37
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Helpers.cs:98
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Menus.cs
+#: top_speed_net/TopSpeed/Menu/Build/Helpers.cs
 msgid "Swipe up to change."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Create.cs:54
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Create.cs
 msgid "Swipe up to enter a room name."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Helpers.cs:111
+#: top_speed_net/TopSpeed/Menu/Build/Helpers.cs
 msgid "Swipe up to select."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Helpers.cs:124
+#: top_speed_net/TopSpeed/Menu/Build/Helpers.cs
 msgid "Swipe up to start."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Helpers.cs:85
+#: top_speed_net/TopSpeed/Menu/Build/Helpers.cs
 msgid "Swipe up to toggle."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Drive.cs:31
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
 msgid "Switch between fixed distance and speed dependent curve announcements."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Game.cs:43
+#: top_speed_net/TopSpeed/Menu/Build/Options/Game.cs
 msgid "Switch between metric and imperial units."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Core.cs:133
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
+msgid ""
+"Switch between spoken curve announcements and non-spoken tones. In tones "
+"mode each type of curve has its own sound: the tighter the curve the higher "
+"the pitch, and the tone plays from the side the curve turns toward, so a "
+"left turn is heard on your left. Tones are the same in every language."
+msgstr ""
+
+#: top_speed_net/TopSpeed/Menu/Build/Core.cs
 msgid ""
 "Switches chat history to the next category in the shared lobby chat view."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Core.cs:126
+#: top_speed_net/TopSpeed/Menu/Build/Core.cs
 msgid ""
 "Switches chat history to the previous category in the shared lobby chat view."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\TrackList.cs:41
+#: top_speed_net/TopSpeed/Core/TrackList.cs
 msgid "Switserland"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:128
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
 msgid "Switzerland"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:22
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Tab"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Mapping\Handler\Controller.cs:30
+#: top_speed_net/TopSpeed/Input/Mapping/Handler/Controller.cs
 msgid "That control is already in use."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:148
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "That crash count takes real effort, and not the good kind."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Mapping\Handler\Keyboard.cs:79
+#: top_speed_net/TopSpeed/Input/Mapping/Handler/Keyboard.cs
 msgid "That key is already in use."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Mapping\Handler\Keyboard.cs:74
+#: top_speed_net/TopSpeed/Input/Mapping/Handler/Keyboard.cs
 msgid "That key is reserved."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:113
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "That many hits should have taught you something by now."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:125
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "That much contact should come with a repair bill."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Shortcuts\Mapping.cs:86
+#: top_speed_net/TopSpeed/Shortcuts/Mapping.cs
 msgid "That shortcut is already in use in this shortcut group."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:120
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "That was a suspicious amount of impact testing."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:104
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "That was already more wall than race."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:109
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "That was enough crashing to make the suspension nervous."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:132
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "That was less racing and more recurring demolition."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:145
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "That was not a clean race. That was one long damage report."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:93
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "That was not elegant, but it was only one mistake."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:99
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "That was one hit too many for a good lap."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:127
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "That was too much crashing for anyone to call it bad luck."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:122
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "That was well past a small mistake and into a pattern."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Input.cs:34
+#: top_speed_net/TopSpeed/Game/Settings/Input.cs
 #, csharp-format
 msgid ""
 "The SDL controller backend could not be initialized. The game has reverted "
@@ -4072,1951 +4058,1971 @@ msgid ""
 "Reason: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Settings\Manager\Apply\Core.cs:16
+#: top_speed_net/TopSpeed/Core/Settings/Manager/Apply/Core.cs
 msgid "The audio section is missing. Defaults were used for audio settings."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:119
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "The barriers are starting to recognize you."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:106
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "The barriers noticed you early."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:133
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "The car deserved a calmer driver than that."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:124
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "The car finished the race despite your repeated attempts to stop it."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:95
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "The car flinched, and so should you."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:114
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "The car was trying to race. You were trying something else."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Connection\Connect.cs:232
+#: top_speed_net/TopSpeed/Core/Multiplayer/Connection/Connect.cs
 msgid "The connection attempt failed for an unknown reason."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Chat\HistoryText.cs:110
+#: top_speed_net/TopSpeed/Core/Multiplayer/Chat/HistoryText.cs
 msgid "The current race was stopped."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Issues.cs:46
+#: top_speed_net/TopSpeed/Game/Settings/Issues.cs
 msgid ""
 "The entire settings file could not be parsed. Defaults were loaded. Review "
 "this error before continuing."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:23
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "The following are the details of all players."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:30
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "The following are the race details for all players."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Check.cs:82
+#: top_speed_net/TopSpeed/Game/Updates/Check.cs
 msgid "The game could not check for updates."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Settings\Manager\Apply\Core.cs:21
+#: top_speed_net/TopSpeed/Core/Settings/Manager/Apply/Core.cs
 msgid "The input section is missing. Defaults were used for input settings."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Settings\Manager\Apply\Input.cs:163
+#: top_speed_net/TopSpeed/Core/Settings/Manager/Apply/Input.cs
 #, csharp-format
 msgid ""
 "The key input.menuShortcuts.bindings[{0}].key has invalid value {1} and was "
 "ignored."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Settings\Manager\Apply\Input.cs:125
+#: top_speed_net/TopSpeed/Core/Settings/Manager/Apply/Input.cs
 #, csharp-format
 msgid "The key {0} has invalid value {1} and was ignored."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Settings\Manager\Validation\Core.cs:147
+#: top_speed_net/TopSpeed/Core/Settings/Manager/Validation/Core.cs
 #, csharp-format
 msgid "The key {0} has invalid value {1}, which was replaced with {2}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:135
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "The mechanics are going to need a very long evening."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Settings\Manager\Apply\Core.cs:41
+#: top_speed_net/TopSpeed/Core/Settings/Manager/Apply/Core.cs
 msgid ""
 "The network section is missing. Defaults were used for network settings."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Connection\Ping.cs:50
+#: top_speed_net/TopSpeed/Core/Multiplayer/Connection/Ping.cs
 #, csharp-format
 msgid "The ping took {0} milliseconds."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:17
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "The race has finished."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Settings\Manager\Apply\Core.cs:26
+#: top_speed_net/TopSpeed/Core/Settings/Manager/Apply/Core.cs
 msgid "The race section is missing. Defaults were used for race settings."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Menu\Help.cs:50
+#: top_speed_net/TopSpeed/Game/Menu/Help.cs
 msgid "The requested help file could not be found."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Menu\Help.cs:73
+#: top_speed_net/TopSpeed/Game/Menu/Help.cs
 msgid "The requested help file could not be opened."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Protocol\TrackPackages\Build\Errors.cs:13
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Protocol\TrackPackages\Build\Errors.cs:19
+#: top_speed_net/TopSpeed.Shared/Protocol/TrackPackages/Build/Errors.cs
 msgid "The selected custom track is invalid."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Panels\RadioPanel\Playlist.cs:63
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Communicator\Runtime\MediaLocal.cs:450
+#: top_speed_net/TopSpeed/Drive/Panels/RadioPanel/Playlist.cs
+#: top_speed_net/TopSpeed/Game/Multiplayer/Communicator/Runtime/MediaLocal.cs
 msgid "The selected folder does not exist."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Panels\RadioPanel\Playlist.cs:60
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Communicator\Runtime\MediaLocal.cs:447
+#: top_speed_net/TopSpeed/Drive/Panels/RadioPanel/Playlist.cs
+#: top_speed_net/TopSpeed/Game/Multiplayer/Communicator/Runtime/MediaLocal.cs
 msgid "The selected folder path is invalid."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Panels\RadioPanel\Selection.cs:54
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Communicator\Runtime\MediaLocal.cs:104
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Communicator\Runtime\MediaLocal.cs:110
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\RadioController\Load.cs:27
+#: top_speed_net/TopSpeed/Drive/Panels/RadioPanel/Selection.cs
+#: top_speed_net/TopSpeed/Game/Multiplayer/Communicator/Runtime/MediaLocal.cs
+#: top_speed_net/TopSpeed/Vehicles/RadioController/Load.cs
 msgid "The selected media file does not exist."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Setup.cs:283
+#: top_speed_net/TopSpeed/Game/Drive/Setup.cs
 msgid ""
 "The selected track could not be loaded. The drive session was not started."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\PitAreaWarning.cs:34
+#: top_speed_net/TopSpeed/Drive/PitAreaWarning.cs
 msgid ""
 "The selected track has no pit area, but fuel consumption and tire wear are "
 "enabled. Without a pit area you cannot refuel or replace tires during the "
 "race."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\PitAreaWarning.cs:40
+#: top_speed_net/TopSpeed/Drive/PitAreaWarning.cs
 msgid ""
 "The selected track has no pit area, but fuel consumption is enabled. Without "
 "a pit area you cannot refuel during the race."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\PitAreaWarning.cs:44
+#: top_speed_net/TopSpeed/Drive/PitAreaWarning.cs
 msgid ""
 "The selected track has no pit area, but tire wear is enabled. Without a pit "
 "area you cannot replace tires during the race."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Setup.cs:63
+#: top_speed_net/TopSpeed/Game/Drive/Setup.cs
 msgid "The selected vehicle does not support the selected transmission mode."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Connection\Connect.cs:175
+#: top_speed_net/TopSpeed/Core/Multiplayer/Connection/Connect.cs
 msgid "The server and client are compatible, but not an exact match."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Connect\Connector\Poll.cs:205
+#: top_speed_net/TopSpeed/Network/Connect/Connector/Poll.cs
 msgid "The server refused the connection."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Connect\Connector\Poll.cs:207
+#: top_speed_net/TopSpeed/Network/Connect/Connector/Poll.cs
 #, csharp-format
 msgid "The server refused the connection. Details: {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Connect\Result\ConnectResult.cs:115
+#: top_speed_net/TopSpeed/Network/Connect/Result/ConnectResult.cs
 msgid ""
 "The server supports an older protocol range. You can continue, but some "
 "features may behave differently."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Settings\Manager\Apply\Core.cs:36
+#: top_speed_net/TopSpeed/Core/Settings/Manager/Apply/Core.cs
 msgid "The speech section is missing. Defaults were used for speech settings."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:110
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "The track gave you several chances, and you used them creatively."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Settings\Manager\Apply\Core.cs:31
+#: top_speed_net/TopSpeed/Core/Settings/Manager/Apply/Core.cs
 msgid "The ui section is missing. Defaults were used for menu settings."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Install.cs:24
+#: top_speed_net/TopSpeed/Game/Updates/Install.cs
 msgid "The update could not be installed automatically."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Dialog.cs:39
+#: top_speed_net/TopSpeed/Game/Updates/Dialog.cs
 msgid "The update download is complete."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Updates\Service.cs:46
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Updates\Service.cs:93
+#: top_speed_net/TopSpeed/Core/Updates/Service.cs
 msgid "The update info file could not be read."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Updates\Service.cs:49
+#: top_speed_net/TopSpeed/Core/Updates/Service.cs
 msgid "The update info file has an invalid version format."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Download.cs:115
+#: top_speed_net/TopSpeed/Game/Updates/Download.cs
 msgid "The update package could not be downloaded."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Install.cs:38
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Install.cs:77
+#: top_speed_net/TopSpeed/Game/Updates/Install.cs
 msgid "The update package file was not found."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Install.cs:63
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Install.cs:110
+#: top_speed_net/TopSpeed/Game/Updates/Install.cs
 msgid "The updater could not be started."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Settings\Manager\ParseErrors.cs:16
+#: top_speed_net/TopSpeed/Core/Settings/Manager/ParseErrors.cs
 #, csharp-format
 msgid "The value '{0}' for the key '{1}' could not be parsed as Boolean. {2}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Protocol\RoomTexts.cs:9
+#: top_speed_net/TopSpeed.Shared/Protocol/RoomTexts.cs
 msgid "There are no bots to remove."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:136
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "There was commitment, just not to staying on the road."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Dialogs\Choice.cs:70
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Dialogs\Dialog.cs:72
+#: top_speed_net/TopSpeed/Menu/Dialogs/Choice.cs
+#: top_speed_net/TopSpeed/Menu/Dialogs/Dialog.cs
 msgid "This dialog is not cancelable. You need to choose an option."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Protocol\RoomTexts.cs:8
+#: top_speed_net/TopSpeed.Shared/Protocol/RoomTexts.cs
 msgid "This game room is unavailable because it is full."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Connect\Connector\Poll.cs:60
+#: top_speed_net/TopSpeed/Network/Connect/Connector/Poll.cs
 msgid ""
 "This server does not support required protocol negotiation. Please update "
 "your server."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:343
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "This shortcut menu has no bindings to reset."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Systems\PitStop.cs:230
+#: top_speed_net/TopSpeed/Drive/Session/Systems/PitStop.cs
 msgid "This track has no pit area."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\Loadout.cs:35
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Drive\Transmission.cs:18
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/Loadout.cs
+#: top_speed_net/TopSpeed/Menu/Build/Drive/Transmission.cs
 msgid "This vehicle does not support the selected transmission mode."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\SavedServers\Delete.cs:17
+#: top_speed_net/TopSpeed/Core/Multiplayer/SavedServers/Delete.cs
 msgid ""
 "This will remove the saved server entry from the list. Are you sure you "
 "would like to continue?"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:321
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 #, csharp-format
 msgid "This will restore all shortcuts in {0} to their default values."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:284
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "This will restore every menu shortcut binding to its default value."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Drive\Bind.cs:39
+#: top_speed_net/TopSpeed/Input/Drive/Bind.cs
 msgid "Throttle"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:88
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Throttle pedal direction"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Core.cs:148
+#: top_speed_net/TopSpeed/Menu/Build/Core.cs
 msgid "Time trial"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:42
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "Time trial complete."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Setup.cs:155
+#: top_speed_net/TopSpeed/Game/Drive/Setup.cs
 msgid "Time trial."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Pit\PitStopMenu.cs:19
+#: top_speed_net/TopSpeed/Game/Drive/Pit/PitStopMenu.cs
 msgid "Tires"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:213
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Toggle media loop"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:258
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Toggle media shuffle"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:153
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Toggle transmission"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:267
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Toggle voice activation"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:205
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Toggles play and pause for streaming media."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Program.cs:144
-#: D:\top_speed\top_speed_net\TopSpeed\Program.cs:158
-#: D:\top_speed\top_speed_net\TopSpeed\Window\Eto\WindowHost.cs:292
-#: D:\top_speed\top_speed_net\TopSpeed\Window\GameWindow.cs:22
-#: D:\top_speed\top_speed_net\TopSpeed\Window\Sdl\WindowHost.cs:308
+#: top_speed_net/TopSpeed/Program.cs
+#: top_speed_net/TopSpeed/Window/Eto/WindowHost.cs
+#: top_speed_net/TopSpeed/Window/GameWindow.cs
+#: top_speed_net/TopSpeed/Window/Sdl/WindowHost.cs
 msgid "Top Speed"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Core\Load\Sections.cs:51
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Core/Load/Sections.cs
 #, csharp-format
 msgid "Top-level key '{0}' is not supported."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Torque\TorqueCurve.cs:80
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Torque/TorqueCurve.cs
 #, csharp-format
 msgid "Torque curve RPM '{0:F0}' must be between 300 and 25000."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Torque\TorqueCurve.cs:89
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Torque/TorqueCurve.cs
 #, csharp-format
 msgid "Torque value '{0:F1}' must be between 0 and 5000 Nm."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Vehicles\Catalog\Data.cs:208
+#: top_speed_net/TopSpeed.Shared/Vehicles/Catalog/Data.cs
 msgid "Toyota Camry"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:154
-#: D:\top_speed\top_speed_net\TopSpeed\Tracks\TrackLoadException.cs:27
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
+#: top_speed_net/TopSpeed/Tracks/TrackLoadException.cs
 msgid "Track"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:170
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 msgid ""
 "Track [meta] must define a weather profile reference, for example 'weather = "
 "default'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Chat\HistoryText.cs:70
+#: top_speed_net/TopSpeed/Core/Multiplayer/Chat/HistoryText.cs
 #, csharp-format
 msgid "Track changed to {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Core.cs:169
+#: top_speed_net/TopSpeed/Menu/Build/Core.cs
 msgid "Track creation guide"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Protocol\TrackPackages\Build\Payload.cs:23
+#: top_speed_net/TopSpeed.Shared/Protocol/TrackPackages/Build/Payload.cs
 msgid "Track data is missing."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:177
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 #, csharp-format
 msgid ""
 "Track default weather profile '{0}' does not match any [weather:{0}] section."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Parser.cs:31
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Parser.cs:55
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Parser.cs
 #, csharp-format
 msgid "Track file not found: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:190
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 #, csharp-format
 msgid "Track lap average: {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Setup.cs:282
+#: top_speed_net/TopSpeed/Game/Drive/Setup.cs
 msgid "Track load error"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:157
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 msgid "Track must include at least one [segment:<id>] section."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\TrackPackages\UploadRuntime.cs:50
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/TrackPackages/UploadRuntime.cs
 msgid "Track package upload failed."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\TrackPackages\UploadRuntime.cs:43
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/TrackPackages/UploadRuntime.cs
 msgid "Track package uploaded successfully."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Parser.cs:65
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Parser.cs
 #, csharp-format
 msgid "Track path must point to a .tsm file inside a track folder: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:163
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 msgid ""
 "Track sets 'pit_area = false' but also defines pit entry/exit segments; "
 "pitting is disabled and the pit segments are ignored."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Protocol\TrackPackages\Build\Assets.cs:23
+#: top_speed_net/TopSpeed.Shared/Protocol/TrackPackages/Build/Assets.cs
 msgid "Track source path is missing, so sound assets cannot be resolved."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\TrackPackages\UploadRuntime.cs:91
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/TrackPackages/UploadRuntime.cs
 msgid "Track upload canceled because the connection was lost."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\TrackPackages\UploadRuntime.cs:36
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/TrackPackages/UploadRuntime.cs
 msgid "Track upload canceled."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Menus.cs:119
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Menus.cs
 msgid "Track, currently random chosen."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Menus.cs:126
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Menus.cs
 #, csharp-format
 msgid "Track, currently {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\TrackPackages\UploadProgress.cs:27
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\TrackPackages\DownloadProgress.cs:40
-#: D:\top_speed\top_speed_net\TopSpeed\Tracks\TrackLoadException.cs:30
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/TrackPackages/UploadProgress.cs
+#: top_speed_net/TopSpeed/Game/Multiplayer/TrackPackages/DownloadProgress.cs
+#: top_speed_net/TopSpeed/Tracks/TrackLoadException.cs
 #, csharp-format
 msgid "Track: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Setup.cs:62
+#: top_speed_net/TopSpeed/Game/Drive/Setup.cs
 msgid "Transmission not supported"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:214
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Turns media loop mode on or off."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:259
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Turns media shuffle mode on or off."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:154
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Turns transmission controls on or off."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:268
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
 msgid "Turns voice activation mode on or off."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Menu\Device.cs:57
+#: top_speed_net/TopSpeed/Game/Menu/Device.cs
 msgid "Unable to activate the selected controller."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Shortcuts\Mapping.cs:97
-#: D:\top_speed\top_speed_net\TopSpeed\Shortcuts\Mapping.cs:103
+#: top_speed_net/TopSpeed/Shortcuts/Mapping.cs
 msgid "Unable to apply the new shortcut."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Menu\About.cs:52
+#: top_speed_net/TopSpeed/Game/Menu/About.cs
 msgid "Unable to copy to clipboard."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Menu\Help.cs:72
+#: top_speed_net/TopSpeed/Game/Menu/Help.cs
 msgid "Unable to open help file"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\TrackPackages\UploadRuntime.cs:65
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/TrackPackages/UploadRuntime.cs
 msgid "Unable to prepare custom track upload."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\DisconnectMapping.cs:62
+#: top_speed_net/TopSpeed/Network/DisconnectMapping.cs
 msgid "Unable to reach server."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Protocol\TrackPackages\Build\Assets.cs:30
+#: top_speed_net/TopSpeed.Shared/Protocol/TrackPackages/Build/Assets.cs
 msgid "Unable to resolve custom track folder path."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Connect\Connector\Helpers.cs:26
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Connect\Connector\Helpers.cs:154
+#: top_speed_net/TopSpeed/Network/Connect/Connector/Helpers.cs
 msgid "Unable to resolve server address."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Connect\Connector\Helpers.cs:31
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Connect\Connector\Helpers.cs:37
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Connect\Connector\Helpers.cs:43
+#: top_speed_net/TopSpeed/Network/Connect/Connector/Helpers.cs
 #, csharp-format
 msgid "Unable to resolve server address: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\DisconnectMapping.cs:77
+#: top_speed_net/TopSpeed/Network/DisconnectMapping.cs
 msgid "Unable to resolve server host."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:48
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Underline"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Game.cs:38
+#: top_speed_net/TopSpeed/Menu/Build/Options/Game.cs
 msgid "Units"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Chat\HistoryText.cs:146
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Formatting.cs:20
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Dialog.cs:60
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:13
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:17
+#: top_speed_net/TopSpeed/Core/Multiplayer/Chat/HistoryText.cs
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Formatting.cs
+#: top_speed_net/TopSpeed/Game/Updates/Dialog.cs
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Unknown"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Settings\Manager\ParseErrors.cs:12
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Install.cs:111
+#: top_speed_net/TopSpeed/Core/Settings/Manager/ParseErrors.cs
+#: top_speed_net/TopSpeed/Game/Updates/Install.cs
 msgid "Unknown error."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Program.cs:78
+#: top_speed_net/TopSpeed/Program.cs
 msgid "Unknown exception."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Core\Load\Sections.cs:58
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Core/Load/Sections.cs
 #, csharp-format
 msgid "Unknown key '{0}' in section [{1}]."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\loader\Custom.cs:25
+#: top_speed_net/TopSpeed/Vehicles/loader/Custom.cs
 msgid "Unknown parse error."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:198
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Unknown room key '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:186
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Unknown room preset '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:46
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 #, csharp-format
 msgid "Unknown section '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Core\Load\Sections.cs:26
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Core/Load/Sections.cs
 #, csharp-format
 msgid "Unknown section [{0}]."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:117
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Unknown segment key '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:297
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Unknown sound key '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Torque\TorqueCurve.cs:33
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Torque/TorqueCurve.cs
 #, csharp-format
 msgid "Unknown torque curve preset '{0}'. Valid values: {1}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Updates\Service.cs:309
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Updates\Service.cs:318
+#: top_speed_net/TopSpeed/Core/Updates/Service.cs
 msgid "Unknown update error."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:175
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Unknown weather key '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\DisconnectMapping.cs:92
+#: top_speed_net/TopSpeed/Network/DisconnectMapping.cs
 msgid "Unsupported peer-to-peer mode."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Settings\Manager\Load.cs:100
+#: top_speed_net/TopSpeed/Core/Settings/Manager/Load.cs
 #, csharp-format
 msgid ""
 "Unsupported settings schema version '{0}'. Expected {1}. Defaults were used."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Transmission\Types.cs:56
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Transmission/Types.cs
 #, csharp-format
 msgid ""
 "Unsupported transmission type '{0}' in supported_types. Valid values: atc, "
 "cvt, dct, manual."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Transmission\Types.cs:25
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Transmission/Types.cs
 #, csharp-format
 msgid ""
 "Unsupported transmission type '{0}'. Valid values: atc, cvt, dct, manual."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:68
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Up"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Check.cs:81
+#: top_speed_net/TopSpeed/Game/Updates/Check.cs
 msgid "Update check failed"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Check.cs:67
+#: top_speed_net/TopSpeed/Game/Updates/Check.cs
 msgid "Update check failed."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Updates\Service.cs:82
+#: top_speed_net/TopSpeed/Core/Updates/Service.cs
 #, csharp-format
 msgid "Update check failed: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Check.cs:28
+#: top_speed_net/TopSpeed/Game/Updates/Check.cs
 msgid "Update check is already in progress."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Updates\Service.cs:77
+#: top_speed_net/TopSpeed/Core/Updates/Service.cs
 msgid "Update check timed out."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Dialog.cs:43
+#: top_speed_net/TopSpeed/Game/Updates/Dialog.cs
 msgid "Update download complete."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Download.cs:91
+#: top_speed_net/TopSpeed/Game/Updates/Download.cs
 msgid "Update download failed."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Updates\Service.cs:59
+#: top_speed_net/TopSpeed/Core/Updates/Service.cs
 #, csharp-format
 msgid "Update package '{0}' was not found in the latest release."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Install.cs:85
+#: top_speed_net/TopSpeed/Game/Updates/Install.cs
 msgid "Update package invalid"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Install.cs:37
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Install.cs:76
+#: top_speed_net/TopSpeed/Game/Updates/Install.cs
 msgid "Update package missing"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Install.cs:62
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Install.cs:109
+#: top_speed_net/TopSpeed/Game/Updates/Install.cs
 msgid "Updater launch failed"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Install.cs:23
+#: top_speed_net/TopSpeed/Game/Updates/Install.cs
 msgid "Updater not found"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Install.cs:100
+#: top_speed_net/TopSpeed/Game/Updates/Install.cs
 msgid "Updater unavailable"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Updates\Service.cs:40
+#: top_speed_net/TopSpeed/Core/Updates/Service.cs
 msgid "Updates are not available on this platform."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Multiplayer.cs:113
+#: top_speed_net/TopSpeed/Menu/Build/Multiplayer.cs
 msgid "Upload a local custom track"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\TrackPackages\Catalog.cs:100
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/TrackPackages/Catalog.cs
 msgid "Upload a local track"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\TrackPackages\UploadProgress.cs:29
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/TrackPackages/UploadProgress.cs
 #, csharp-format
 msgid "Uploaded size: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\TrackPackages\UploadProgress.cs:34
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/TrackPackages/UploadProgress.cs
 msgid "Uploading track..."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Drive.cs:39
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
 msgid ""
 "Use LEFT or RIGHT to change by 0.1 seconds, PAGE UP or PAGE DOWN to change "
 "by 1.0 second, HOME for maximum, END for minimum."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Menus.cs:45
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Helpers.cs:149
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Menus.cs
+#: top_speed_net/TopSpeed/Menu/Build/Helpers.cs
 msgid ""
 "Use LEFT or RIGHT to change by 1, PAGE UP or PAGE DOWN to change by 10, HOME "
 "for maximum, END for minimum."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Create.cs:26
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Create.cs:40
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Menus.cs:54
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Helpers.cs:136
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Create.cs
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Menus.cs
+#: top_speed_net/TopSpeed/Menu/Build/Helpers.cs
 msgid "Use LEFT or RIGHT to change."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Mapping\Handler\Keyboard.cs:36
+#: top_speed_net/TopSpeed/Input/Mapping/Handler/Keyboard.cs
 msgid "Use both modifier keys"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Drive\Bind.cs:44
+#: top_speed_net/TopSpeed/Input/Drive/Bind.cs
 msgid "Use horn"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:60
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Use motion sensors for steering"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Game.cs:72
+#: top_speed_net/TopSpeed/Menu/Build/Options/Game.cs
 msgid "Use proxy for update downloads"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Multiplayer\Session\Network\Participants.cs:149
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:86
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Single\Session\Format.cs:35
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Car.cs:38
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\VehicleDefinition.cs:18
+#: top_speed_net/TopSpeed/Drive/Multiplayer/Session/Network/Participants.cs
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
+#: top_speed_net/TopSpeed/Drive/Single/Session/Format.cs
+#: top_speed_net/TopSpeed/Vehicles/Car.cs
+#: top_speed_net/TopSpeed/Vehicles/VehicleDefinition.cs
 msgid "Vehicle"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Core.cs:170
+#: top_speed_net/TopSpeed/Menu/Build/Core.cs
 msgid "Vehicle creation guide"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\VolumeShortcuts.cs:236
+#: top_speed_net/TopSpeed/Game/Settings/VolumeShortcuts.cs
 msgid "Vehicle engine"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Volume.cs:20
+#: top_speed_net/TopSpeed/Menu/Build/Options/Volume.cs
 msgid "Vehicle engine sounds"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Volume.cs:25
+#: top_speed_net/TopSpeed/Menu/Build/Options/Volume.cs
 msgid "Vehicle event sounds"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\VolumeShortcuts.cs:237
+#: top_speed_net/TopSpeed/Game/Settings/VolumeShortcuts.cs
 msgid "Vehicle events"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Core\Load\File.cs:28
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Core/Load/File.cs
 #, csharp-format
 msgid "Vehicle file not found: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Core\Load\File.cs:22
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Core/Load/File.cs
 msgid "Vehicle file path is empty."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Lifecycle\Shortcuts.cs:88
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Menu\LobbyAndControls.cs:42
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Lifecycle/Shortcuts.cs
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Menu/LobbyAndControls.cs
 msgid "View game rules"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Speech.cs:129
+#: top_speed_net/TopSpeed/Menu/Build/Options/Speech.cs
 msgid "Voice"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Coordinator\Communicator.cs:31
+#: top_speed_net/TopSpeed/Core/Multiplayer/Coordinator/Communicator.cs
 msgid "Voice activation off"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Coordinator\Communicator.cs:30
+#: top_speed_net/TopSpeed/Core/Multiplayer/Coordinator/Communicator.cs
 msgid "Voice activation on"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Audio.cs:27
+#: top_speed_net/TopSpeed/Menu/Build/Options/Audio.cs
 #, csharp-format
 msgid "Voice input device: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Audio.cs:77
+#: top_speed_net/TopSpeed/Game/Settings/Audio.cs
 msgid "Voice input set to automatic."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Audio.cs:79
+#: top_speed_net/TopSpeed/Game/Settings/Audio.cs
 #, csharp-format
 msgid "Voice input set to {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Speech.cs:118
+#: top_speed_net/TopSpeed/Menu/Build/Options/Speech.cs
 #, csharp-format
 msgid "Voice: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\VolumeShortcuts.cs:246
+#: top_speed_net/TopSpeed/Game/Settings/VolumeShortcuts.cs
 msgid "Volume"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Main.cs:24
+#: top_speed_net/TopSpeed/Menu/Build/Options/Main.cs
 msgid "Volume settings"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Issues\Issue.cs:21
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Selection\VehicleSource.cs:47
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Selection\VehicleSource.cs:90
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Issues/Issue.cs
+#: top_speed_net/TopSpeed/Core/Selection/VehicleSource.cs
 msgid "Warning"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Issues.cs:102
+#: top_speed_net/TopSpeed/Game/Settings/Issues.cs
 msgid "Warning:"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:148
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:152
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:160
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:164
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Weather key '{0}' must be greater than zero."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:170
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Weather key '{0}' must be non-negative."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:79
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 msgid "Weather transition seconds must be finite and non-negative."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Menu\Wizard.cs:12
+#: top_speed_net/TopSpeed/Game/Menu/Wizard.cs
 msgid ""
 "Welcome to Top Speed setup. On the next screens, you will choose your "
 "language and then calibrate the screen-reader speaking rate."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Race\Runtime.cs:282
+#: top_speed_net/TopSpeed/Game/Multiplayer/Race/Runtime.cs
 msgid "What would you like to do?"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Core.cs:171
+#: top_speed_net/TopSpeed/Menu/Build/Core.cs
 msgid "What's new"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Check.cs:192
+#: top_speed_net/TopSpeed/Game/Updates/Check.cs
 msgid "What's new in this version:"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Audio.cs:16
+#: top_speed_net/TopSpeed/Menu/Build/Options/Audio.cs
 msgid ""
 "When checked, Three-D audio uses HRTF spatialization for more realistic "
 "positioning."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Game.cs:52
+#: top_speed_net/TopSpeed/Menu/Build/Options/Game.cs
 msgid ""
 "When checked, each menu automatically focuses and announces the first item "
 "after the title."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Game.cs:47
+#: top_speed_net/TopSpeed/Menu/Build/Options/Game.cs
 msgid "When checked, menu items can speak usage hints after a short delay."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Game.cs:63
+#: top_speed_net/TopSpeed/Menu/Build/Options/Game.cs
 msgid ""
 "When checked, menu navigation sounds pan left or right based on the item "
 "position."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Game.cs:57
+#: top_speed_net/TopSpeed/Menu/Build/Options/Game.cs
 msgid "When checked, menu navigation wraps from the last item to the first."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Speech.cs:61
+#: top_speed_net/TopSpeed/Menu/Build/Options/Speech.cs
 msgid ""
 "When checked, new spoken messages interrupt the current screen reader "
 "speech. Menu titles and usage hints are not affected."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Game.cs:33
+#: top_speed_net/TopSpeed/Menu/Build/Options/Game.cs
 msgid "When checked, random track selection can include custom tracks."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Game.cs:37
+#: top_speed_net/TopSpeed/Menu/Build/Options/Game.cs
 msgid "When checked, random vehicle selection can include custom vehicles."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:63
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
+msgid ""
+"When checked, spoken status reports are shortened for experienced players: "
+"labels such as \"lap percentage\" and \"gear\" are dropped, and the number "
+"row gives a quick position rundown."
+msgstr ""
+
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid ""
 "When checked, steering uses Android motion sensors instead of drag gestures."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Game.cs:71
+#: top_speed_net/TopSpeed/Menu/Build/Options/Game.cs
 msgid "When checked, the game checks for updates automatically after the logo."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Audio.cs:24
+#: top_speed_net/TopSpeed/Menu/Build/Options/Audio.cs
 msgid ""
 "When checked, the game uses the device channel count and sample rate. "
 "Restart required."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Game.cs:67
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
+msgid ""
+"When checked, the number row and player information report a car's lap and "
+"the turn it is in or approaching, spoken like a spotter, instead of its race "
+"percentage. This applies to your own car and to any other driver you check "
+"with the number row. Turns are numbered from the track's curves, so the "
+"count may differ from a real circuit's official turn numbers."
+msgstr ""
+
+#: top_speed_net/TopSpeed/Menu/Build/Options/Game.cs
 msgid "When checked, the startup logo audio plays when the game launches."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Game.cs:76
+#: top_speed_net/TopSpeed/Menu/Build/Options/Game.cs
 msgid ""
 "When checked, update package downloads are routed through your proxy URL."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Menus.cs:100
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Menus.cs
 msgid "When enabled, cars burn fuel and players must pit to refuel."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Menus.cs:94
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Menus.cs
 msgid ""
 "When enabled, room hosts can upload and select custom tracks from this "
 "server."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:45
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid ""
 "When enabled, throttle, brake, and steering ramp in over time instead of "
 "jumping instantly to full value."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Menus.cs:106
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Menus.cs
 msgid ""
 "When enabled, tires wear and lose grip and players must pit to replace them."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Menus.cs:88
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Menus.cs
 msgid ""
 "When enabled, vehicle collisions are disabled and vehicles can pass through "
 "each other."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Drive.cs:75
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
 msgid ""
 "When enabled, your car burns fuel and you must pit to refuel. Turn off to "
 "race without fuel limits."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Drive.cs:79
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
 msgid ""
 "When enabled, your tires wear and lose grip and you must pit to replace "
 "them. Turn off to race without tire wear."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Menu\LobbyAndControls.cs:43
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Menu/LobbyAndControls.cs
 msgid "Who is currently present in this game room"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Menu\LobbyAndControls.cs:16
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Menu/LobbyAndControls.cs
 msgid "Who is online"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:128
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "X minus"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:129
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "X plus"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:130
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Y minus"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:131
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Y plus"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Vehicles\Catalog\Data.cs:396
+#: top_speed_net/TopSpeed.Shared/Vehicles/Catalog/Data.cs
 msgid "Yamaha YZF-R1"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Session.cs:27
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Input.cs:59
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Input.cs:87
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:286
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:324
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Session.cs
+#: top_speed_net/TopSpeed/Game/Settings/Input.cs
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "Yes"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\LoadoutExit.cs:27
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/LoadoutExit.cs
 msgid "Yes, cancel the current game"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\SavedServers\Delete.cs:19
+#: top_speed_net/TopSpeed/Core/Multiplayer/SavedServers/Delete.cs
 msgid "Yes, delete this server"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\Room.cs:31
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/Room.cs
 msgid "Yes, leave this game room"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\LoadoutExit.cs:36
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/LoadoutExit.cs
 msgid "Yes, quit race preparation"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Race\Runtime.cs:260
+#: top_speed_net/TopSpeed/Game/Multiplayer/Race/Runtime.cs
 msgid "Yes, quit the race"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Check.cs:94
+#: top_speed_net/TopSpeed/Game/Updates/Check.cs
 msgid "You are already using the latest version."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\Room.cs:20
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Menu\LobbyAndControls.cs:29
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Menu\Players.cs:15
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Draft.cs:13
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Menus.cs:16
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Menus.cs:72
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Rules.cs:12
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/Room.cs
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Menu/LobbyAndControls.cs
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Menu/Players.cs
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Draft.cs
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Menus.cs
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Rules.cs
 msgid "You are not currently inside a game room."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Coordinator\Chat\Input.cs:38
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Coordinator\Chat\Input.cs:87
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\Loadout.cs:23
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\LoadoutExit.cs:85
+#: top_speed_net/TopSpeed/Core/Multiplayer/Coordinator/Chat/Input.cs
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/Loadout.cs
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/LoadoutExit.cs
 msgid "You are not in a game room."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Chat\HistoryText.cs:22
+#: top_speed_net/TopSpeed/Core/Multiplayer/Chat/HistoryText.cs
 msgid "You are now host of this room."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Install.cs:39
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Updates\Install.cs:78
+#: top_speed_net/TopSpeed/Game/Updates/Install.cs
 msgid "You can download the update again or install manually."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:79
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "You crashed once."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:85
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 #, csharp-format
 msgid "You crashed {0} times."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:154
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 #, csharp-format
 msgid "You finished in {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:146
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "You fought the course all the way through and still lost."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:92
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "You gave the wall a quick hello and moved on."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Chat\HistoryText.cs:11
+#: top_speed_net/TopSpeed/Core/Multiplayer/Chat/HistoryText.cs
 #, csharp-format
 msgid "You joined {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:112
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "You kept finding the wrong line and proving it."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\LoadoutExit.cs:93
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/LoadoutExit.cs
 msgid "You left race preparation and returned to room controls."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Chat\HistoryText.cs:17
+#: top_speed_net/TopSpeed/Core/Multiplayer/Chat/HistoryText.cs
 msgid "You left the game room."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:98
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "You made it through with one clear mistake and no excuse."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Mapping\Handler\Keyboard.cs:41
+#: top_speed_net/TopSpeed/Input/Mapping/Handler/Keyboard.cs
 #, csharp-format
 msgid "You pressed {0}. Choose a modifier option."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:121
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "You spent a lot of time negotiating with walls and losing."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:138
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "You spent more time recovering than driving cleanly."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:134
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "You treated the entire event like an extended crash montage."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:126
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "You were driving like the brakes were optional."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:111
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "You were driving like the corners had something against you."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:107
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "You were supposed to follow the road, not sample it repeatedly."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Connect\Connector\Helpers.cs:135
+#: top_speed_net/TopSpeed/Network/Connect/Connector/Helpers.cs
 #, csharp-format
 msgid ""
 "Your client protocol version is {0}. This server supports protocol versions "
 "{1}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Connection\Connect.cs:178
+#: top_speed_net/TopSpeed/Core/Multiplayer/Connection/Connect.cs
 #, csharp-format
 msgid "Your client protocol version: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:56
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "Your latest run did not beat the best record. Details:"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:49
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 msgid "Your new result details:"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:178
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 #, csharp-format
 msgid "Your quickest lap this run: {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:153
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 #, csharp-format
 msgid "Your time: {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:132
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Z minus"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:133
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "Z plus"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\Room.cs:171
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/Room.cs
 msgid "add bot request"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Chat\Buffers.cs:213
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Drive.cs:21
+#: top_speed_net/TopSpeed/Core/Multiplayer/Chat/Buffers.cs
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
 msgid "all"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Policy\PolicyValidation.cs:42
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Policy/PolicyValidation.cs
 msgid "auto_downshift_rpm must be 0 or between idle_rpm and rev_limiter."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Validation\Core.cs:50
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Validation/Core.cs
 msgid "auto_shift_rpm must be 0 or between idle_rpm and rev_limiter."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Policy\PolicyValidation.cs:36
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Policy/PolicyValidation.cs
 msgid "auto_upshift_rpm must be 0 or between idle_rpm and rev_limiter."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Systems\CoreRequests.cs:113
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Speech.cs:31
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Speech.cs:38
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Speech.cs:115
+#: top_speed_net/TopSpeed/Drive/Session/Systems/CoreRequests.cs
+#: top_speed_net/TopSpeed/Menu/Build/Options/Speech.cs
 msgid "automatic"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Online.cs:67
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Online.cs
 msgid "available"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Helpers.cs:171
+#: top_speed_net/TopSpeed/Menu/Build/Helpers.cs
 msgid "both"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Speech.cs:102
+#: top_speed_net/TopSpeed/Menu/Build/Options/Speech.cs
 msgid "braille"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Items\CheckBox.cs:25
+#: top_speed_net/TopSpeed/Menu/Items/CheckBox.cs
 msgid "check box"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Items\CheckBox.cs:36
+#: top_speed_net/TopSpeed/Menu/Items/CheckBox.cs
 msgid "checked"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Systems\TireTemperatureStatus.cs:23
+#: top_speed_net/TopSpeed/Drive/Session/Systems/TireTemperatureStatus.cs
 msgid "cold tires"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Chat\Buffers.cs:211
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
+#, csharp-format
+msgid "completing lap {0}"
+msgstr ""
+
+#: top_speed_net/TopSpeed/Core/Multiplayer/Chat/Buffers.cs
 msgid "connections"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Helpers.cs:170
+#: top_speed_net/TopSpeed/Menu/Build/Helpers.cs
 msgid "controller"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Drive.cs:20
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
 msgid "curves only"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\TrackPackages\Catalog.cs:74
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/TrackPackages/Catalog.cs
 msgid "custom track list request"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Game.cs:107
+#: top_speed_net/TopSpeed/Menu/Build/Options/Game.cs
 msgid "default"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Helpers.cs:162
+#: top_speed_net/TopSpeed/Menu/Build/Helpers.cs
 #, csharp-format
 msgid "default ({0})"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Rules.cs:53
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Rules.cs:56
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Rules.cs:59
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Rules.cs:62
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Rules.cs
 msgid "disabled"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Drive.cs:65
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
 msgid "easy"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Rules.cs:52
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Rules.cs:55
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Rules.cs:58
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Rules.cs:61
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Rules.cs
 msgid "enabled"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:276
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 msgid "end_area cannot be empty."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Parse\Powertrain.cs:43
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Parse/Powertrain.cs
 #, csharp-format
 msgid "engine_displacement_l must be between {0} and {1} liters."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Drive.cs:28
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
+msgid "finished"
+msgstr ""
+
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
 msgid "fixed distance"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Systems\CoreRequests.cs:243
+#: top_speed_net/TopSpeed/Drive/Session/Systems/CoreRequests.cs
 msgid "fuel consumption off"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Parse\Powertrain.cs:28
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Parse/Powertrain.cs
 #, csharp-format
 msgid "fuel must be between {0} and {1} liters."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Systems\CoreRequests.cs:265
+#: top_speed_net/TopSpeed/Drive/Session/Systems/CoreRequests.cs
 #, csharp-format
 msgid "fuel {0:F1} gallons, {1:F0} percent"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Systems\CoreRequests.cs:258
+#: top_speed_net/TopSpeed/Drive/Session/Systems/CoreRequests.cs
 #, csharp-format
 msgid "fuel {0:F1} gallons, {1:F0} percent, {2:F1} miles per gallon"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Systems\CoreRequests.cs:281
+#: top_speed_net/TopSpeed/Drive/Session/Systems/CoreRequests.cs
 #, csharp-format
 msgid "fuel {0:F1} liters, {1:F0} percent"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Systems\CoreRequests.cs:274
+#: top_speed_net/TopSpeed/Drive/Session/Systems/CoreRequests.cs
 #, csharp-format
 msgid "fuel {0:F1} liters, {1:F0} percent, {2:F1} liters per 100 kilometers"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\LoadoutExit.cs:63
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/LoadoutExit.cs
 msgid "game cancel request"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Chat\HistoryText.cs:139
+#: top_speed_net/TopSpeed/Core/Multiplayer/Chat/HistoryText.cs
 msgid "game room"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Draft.cs:145
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Draft.cs
 msgid "game rules change request"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Validation\Gears.cs:21
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Validation/Gears.cs
 #, csharp-format
 msgid "gear_ratios count ({0}) must match number_of_gears ({1})."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Validation\Gears.cs:44
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Validation/Gears.cs
 msgid "gear_ratios must be non-increasing from gear 1 to last gear."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Validation\Gears.cs:33
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Validation/Gears.cs
 #, csharp-format
 msgid "gear_ratios[{0}] is outside allowed range 0.20 to 8.00."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Chat\Buffers.cs:209
+#: top_speed_net/TopSpeed/Core/Multiplayer/Chat/Buffers.cs
 msgid "global chat"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Drive.cs:67
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
 msgid "hard"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Systems\CoreRequests.cs:325
+#: top_speed_net/TopSpeed/Drive/Session/Systems/CoreRequests.cs
 msgid "heavy wear"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Validation\Core.cs:110
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Validation/Core.cs
 msgid ""
 "high_speed_steer_full_kph must be greater than high_speed_steer_start_kph."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Systems\TireTemperatureStatus.cs:17
+#: top_speed_net/TopSpeed/Drive/Session/Systems/TireTemperatureStatus.cs
 msgid "hot tires"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Game.cs:40
+#: top_speed_net/TopSpeed/Menu/Build/Options/Game.cs
 msgid "imperial"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Helpers.cs:169
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Helpers.cs:172
+#: top_speed_net/TopSpeed/Menu/Build/Helpers.cs
 msgid "keyboard"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Draft.cs:96
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Draft.cs
 msgid "lap count change request"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Drive.cs:46
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
+#, csharp-format
+msgid "lap {0}"
+msgstr ""
+
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
+#, csharp-format
+msgid "lap {0} approaching finish"
+msgstr ""
+
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
+#, csharp-format
+msgid "lap {0} approaching turn {1}"
+msgstr ""
+
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
+#, csharp-format
+msgid "lap {0} turn {1}"
+msgstr ""
+
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
 msgid "laps only"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Transmission\Modes.cs:53
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Transmission/Modes.cs
 msgid ""
 "launch_coupling_max must be greater than or equal to launch_coupling_min in "
 "[transmission_atc]."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Transmission\Modes.cs:181
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Transmission/Modes.cs
 msgid ""
 "launch_coupling_max must be greater than or equal to launch_coupling_min in "
 "[transmission_cvt]."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Transmission\Modes.cs:104
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Transmission/Modes.cs
 msgid ""
 "launch_coupling_max must be greater than or equal to launch_coupling_min in "
 "[transmission_dct]."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Validation\Core.cs:68
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Validation/Core.cs
 msgid "launch_rpm must not exceed rev_limiter."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Systems\CoreRequests.cs:329
+#: top_speed_net/TopSpeed/Drive/Session/Systems/CoreRequests.cs
 msgid "light wear"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Domain\Online\Map.cs:9
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Online.cs:12
+#: top_speed_net/TopSpeed/Core/Multiplayer/Domain/Online/Map.cs
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Online.cs
 msgid "main room"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Validation\Core.cs:31
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Validation/Core.cs
 msgid "max_rpm must be greater than or equal to idle_rpm."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Game.cs:39
+#: top_speed_net/TopSpeed/Menu/Build/Options/Game.cs
 msgid "metric"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Parse\Powertrain.cs:83
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Parse/Powertrain.cs
 msgid ""
 "min_coupled_rise_full_rpm_per_s must be greater than or equal to "
 "min_coupled_rise_idle_rpm_per_s."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Settings\Manager\Load.cs:101
+#: top_speed_net/TopSpeed/Core/Settings/Manager/Load.cs
 msgid "missing"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Systems\CoreRequests.cs:327
+#: top_speed_net/TopSpeed/Drive/Session/Systems/CoreRequests.cs
 msgid "moderate wear"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Systems\CoreRequests.cs:331
+#: top_speed_net/TopSpeed/Drive/Session/Systems/CoreRequests.cs
 msgid "new tires"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:11
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:127
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Display\Text.cs:176
+#: top_speed_net/TopSpeed/Input/Display/Text.cs
 msgid "none"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Drive.cs:66
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
 msgid "normal"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Items\CheckBox.cs:37
+#: top_speed_net/TopSpeed/Menu/Items/CheckBox.cs
 msgid "not checked"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Drive.cs:19
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Drive.cs:45
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
 msgid "off"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Drive.cs:47
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
 msgid "on"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Browser.cs:64
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Browser.cs
 msgid "one-on-one"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Online.cs:27
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Online.cs
 msgid "online players request"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Systems\TireTemperatureStatus.cs:19
+#: top_speed_net/TopSpeed/Drive/Session/Systems/TireTemperatureStatus.cs
 msgid "optimal temperature"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Selection\VehicleSource.cs:58
+#: top_speed_net/TopSpeed/Core/Selection/VehicleSource.cs
 #, csharp-format
 msgid "optional sound not found, no sound will play: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Selection\VehicleSource.cs:62
+#: top_speed_net/TopSpeed/Core/Selection/VehicleSource.cs
 #, csharp-format
 msgid "optional sound problem, no sound will play: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Systems\TireTemperatureStatus.cs:15
+#: top_speed_net/TopSpeed/Drive/Session/Systems/TireTemperatureStatus.cs
 msgid "overheated tires"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:165
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
 msgid "panel"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Panels\RadioPanel\Playback.cs:33
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Communicator\Runtime\MediaLocal.cs:214
+#: top_speed_net/TopSpeed/Drive/Panels/RadioPanel/Playback.cs
+#: top_speed_net/TopSpeed/Game/Multiplayer/Communicator/Runtime/MediaLocal.cs
 msgid "paused"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Validation\Core.cs:59
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Validation/Core.cs
 msgid "peak_torque_rpm must be between idle_rpm and rev_limiter."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:63
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
 msgid "percent"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Validation\Core.cs:99
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Validation/Core.cs
 #, csharp-format
 msgid "pitch_curve_exponent must be between {0} and {1}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Draft.cs:106
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Draft.cs
 msgid "player count change request"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Single\Session\Results.cs:50
+#: top_speed_net/TopSpeed/Drive/Single/Session/Results.cs
 #, csharp-format
 msgid "player {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Panels\RadioPanel\Playback.cs:25
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Panels\RadioPanel\Playback.cs:32
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Communicator\Runtime\MediaLocal.cs:205
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Communicator\Runtime\MediaLocal.cs:213
+#: top_speed_net/TopSpeed/Drive/Panels/RadioPanel/Playback.cs
+#: top_speed_net/TopSpeed/Game/Multiplayer/Communicator/Runtime/MediaLocal.cs
 msgid "playing"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\LoadoutExit.cs:91
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/LoadoutExit.cs
 msgid "race preparation withdrawal"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\Room.cs:93
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\Room.cs:153
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/Room.cs
 msgid "race start request"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Browser.cs:66
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Browser.cs
 msgid "race with bots"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Browser.cs:65
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Browser.cs
 msgid "race without bots"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Online.cs:66
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Online.cs
 msgid "racing"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Items\RadioButton.cs:48
+#: top_speed_net/TopSpeed/Menu/Items/RadioButton.cs
 msgid "radio button"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Transmission\Modes.cs:163
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Transmission/Modes.cs
 msgid ""
 "ratio_max must be greater than or equal to ratio_min in [transmission_cvt]."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\Loadout.cs:41
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/Loadout.cs
 msgid "ready state"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\Room.cs:189
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/Room.cs
 msgid "remove bot request"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Selection\VehicleSource.cs:57
+#: top_speed_net/TopSpeed/Core/Selection/VehicleSource.cs
 #, csharp-format
 msgid "required sound not found, will use built in fallback: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Selection\VehicleSource.cs:61
+#: top_speed_net/TopSpeed/Core/Selection/VehicleSource.cs
 #, csharp-format
 msgid "required sound problem, will use built in fallback: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Validation\Core.cs:40
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Validation/Core.cs
 msgid "rev_limiter must be between idle_rpm and max_rpm."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Chat\Buffers.cs:210
+#: top_speed_net/TopSpeed/Core/Multiplayer/Chat/Buffers.cs
 msgid "room chat"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Create.cs:120
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Create.cs
 msgid "room create request"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Chat\Buffers.cs:212
+#: top_speed_net/TopSpeed/Core/Multiplayer/Chat/Buffers.cs
 msgid "room events"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Browser.cs:37
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Browser.cs
 msgid "room join request"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Actions\Room.cs:58
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Actions/Room.cs
 msgid "room leave request"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Browser.cs:24
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Browser.cs
 msgid "room list request"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\TrackSelection.cs:25
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/TrackSelection.cs
 msgid "room state refresh request"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Systems\CoreRequests.cs:112
+#: top_speed_net/TopSpeed/Drive/Session/Systems/CoreRequests.cs
 msgid "shift on demand"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Validation\Core.cs:86
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Validation/Core.cs
 msgid "shift_freq must be between idle_freq and top_freq."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Validation\Transmission.cs:35
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Validation/Transmission.cs
 msgid ""
 "shift_on_demand is ignored because supported_types does not include an "
 "automatic transmission type."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Items\Slider.cs:78
+#: top_speed_net/TopSpeed/Menu/Items/Slider.cs
 msgid "slider"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Speech.cs:101
+#: top_speed_net/TopSpeed/Menu/Build/Options/Speech.cs
 msgid "speech only"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Speech.cs:103
+#: top_speed_net/TopSpeed/Menu/Build/Options/Speech.cs
 msgid "speech with braille"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Drive.cs:27
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
 msgid "speed dependent"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:266
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
+msgid "spoken"
+msgstr ""
+
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 msgid "start_area cannot be empty."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Items\Switch.cs:37
+#: top_speed_net/TopSpeed/Menu/Items/Switch.cs
 msgid "switch"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Transmission\Modes.cs:172
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Transmission/Modes.cs
 msgid ""
 "target_rpm_high must be greater than or equal to target_rpm_low in "
 "[transmission_cvt]."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:373
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 msgid "this menu"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Systems\CoreRequests.cs:289
+#: top_speed_net/TopSpeed/Drive/Session/Systems/CoreRequests.cs
 msgid "tire wear off"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Validation\Tires.cs:35
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Validation/Tires.cs
 msgid "tire_aspect must be between 5 and 150."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Validation\Tires.cs:20
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Validation/Tires.cs
 msgid "tire_circumference must be between 0.2 and 5.0 meters."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Validation\Tires.cs:37
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Validation/Tires.cs
 msgid "tire_rim must be between 4 and 30 inches."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Validation\Tires.cs:33
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Validation/Tires.cs
 msgid "tire_width must be between 20 and 450 mm."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Systems\CoreRequests.cs:313
+#: top_speed_net/TopSpeed/Drive/Session/Systems/CoreRequests.cs
 #, csharp-format
 msgid "tires {0:F0} percent wear, {1:F0} degrees Celsius, {2}, {3}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Systems\CoreRequests.cs:305
+#: top_speed_net/TopSpeed/Drive/Session/Systems/CoreRequests.cs
 #, csharp-format
 msgid "tires {0:F0} percent wear, {1:F0} degrees Fahrenheit, {2}, {3}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Validation\Core.cs:77
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
+msgid "tones"
+msgstr ""
+
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Validation/Core.cs
 msgid "top_freq must be greater than or equal to idle_freq."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Policy\PolicyValidation.cs:22
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Policy/PolicyValidation.cs
 #, csharp-format
 msgid "top_speed_gear must be within 1..{0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Draft.cs:89
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Draft.cs
 msgid "track change request"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\TrackPackages\UploadRuntime.cs:124
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/TrackPackages/UploadRuntime.cs
 msgid "track upload cancel"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\TrackPackages\UploadRuntime.cs:153
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/TrackPackages/UploadRuntime.cs
 msgid "track upload chunk"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\TrackPackages\UploadRuntime.cs:168
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/TrackPackages/UploadRuntime.cs
 msgid "track upload completion"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\TrackPackages\UploadRuntime.cs:105
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/TrackPackages/UploadRuntime.cs
 msgid "track upload start"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Issues.cs:26
+#: top_speed_net/TopSpeed/Game/Settings/Issues.cs
 msgid "unknown"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Systems\TireTemperatureStatus.cs:21
+#: top_speed_net/TopSpeed/Drive/Session/Systems/TireTemperatureStatus.cs
 msgid "warming up tires"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Systems\CoreRequests.cs:323
+#: top_speed_net/TopSpeed/Drive/Session/Systems/CoreRequests.cs
 msgid "worn tires"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Systems\CoreRequests.cs:228
+#: top_speed_net/TopSpeed/Drive/Session/Systems/CoreRequests.cs
 #, csharp-format
 msgid "{0:F0} feet traveled"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Systems\CoreRequests.cs:193
+#: top_speed_net/TopSpeed/Drive/Session/Systems/CoreRequests.cs
 #, csharp-format
 msgid "{0:F0} kilometers per hour, {1:F0} RPM, {2:F0} horsepower"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Systems\CoreRequests.cs:236
+#: top_speed_net/TopSpeed/Drive/Session/Systems/CoreRequests.cs
 #, csharp-format
 msgid "{0:F0} meters traveled"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Systems\CoreRequests.cs:185
+#: top_speed_net/TopSpeed/Drive/Session/Systems/CoreRequests.cs
 #, csharp-format
 msgid "{0:F0} miles per hour, {1:F0} RPM, {2:F0} horsepower"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Systems\CoreRequests.cs:234
+#: top_speed_net/TopSpeed/Drive/Session/Systems/CoreRequests.cs
 #, csharp-format
 msgid "{0:F1} kilometers traveled"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Systems\CoreRequests.cs:226
+#: top_speed_net/TopSpeed/Drive/Session/Systems/CoreRequests.cs
 #, csharp-format
 msgid "{0:F1} miles traveled"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Dialogs\Announcement.cs:9
+#: top_speed_net/TopSpeed/Menu/Dialogs/Announcement.cs
 #, csharp-format
 msgid "{0}  dialog"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Dialogs\Announcement.cs:10
+#: top_speed_net/TopSpeed/Menu/Dialogs/Announcement.cs
 #, csharp-format
 msgid "{0}  dialog  {1}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Coordinator\Communicator.cs:65
+#: top_speed_net/TopSpeed/Core/Multiplayer/Coordinator/Communicator.cs
 #, csharp-format
 msgid "{0} MHz"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Connection\Connect.cs:160
+#: top_speed_net/TopSpeed/Core/Multiplayer/Connection/Connect.cs
 #, csharp-format
 msgid "{0} Message of the day: {1}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Connect\Connector\Connect.cs:142
-#: D:\top_speed\top_speed_net\TopSpeed\Network\Connect\Connector\Poll.cs:196
+#: top_speed_net/TopSpeed/Network/Connect/Connector/Connect.cs
+#: top_speed_net/TopSpeed/Network/Connect/Connector/Poll.cs
 #, csharp-format
 msgid "{0} Socket error: {1}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultFmt.cs:49
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultFmt.cs
 #, csharp-format
 msgid "{0} and {1}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Chat\HistoryText.cs:91
+#: top_speed_net/TopSpeed/Core/Multiplayer/Chat/HistoryText.cs
 #, csharp-format
 msgid "{0} changed ready state."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:86
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 #, csharp-format
 msgid "{0} crashes."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Browser.cs:71
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Browser.cs
 #, csharp-format
 msgid "{0} game with {1} people, maximum {2} players"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Controls.cs:229
+#: top_speed_net/TopSpeed/Menu/Build/Options/Controls.cs
 #, csharp-format
 msgid "{0} has no shortcuts."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Chat\HistoryText.cs:28
+#: top_speed_net/TopSpeed/Core/Multiplayer/Chat/HistoryText.cs
 #, csharp-format
 msgid "{0} joined the current room."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\Issues.cs:31
+#: top_speed_net/TopSpeed/Game/Settings/Issues.cs
 #, csharp-format
 msgid "{0} key '{1}': {2}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Rules.cs:41
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Rules.cs
 #, csharp-format
 msgid "{0} lap"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Rules.cs:42
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Rules.cs
 #, csharp-format
 msgid "{0} laps"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Chat\HistoryText.cs:35
+#: top_speed_net/TopSpeed/Core/Multiplayer/Chat/HistoryText.cs
 #, csharp-format
 msgid "{0} left the current room."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:39
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
 #, csharp-format
 msgid "{0} milliseconds"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:24
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultFmt.cs:37
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultFmt.cs
 #, csharp-format
 msgid "{0} minute"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:25
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultFmt.cs:38
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultFmt.cs
 #, csharp-format
 msgid "{0} minutes"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Policy\PolicyValidation.cs:76
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Policy/PolicyValidation.cs
 #, csharp-format
 msgid "{0} must be a float between 0 and 2 seconds."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Vehicles\Parsing\Build\Policy\PolicyValidation.cs:90
+#: top_speed_net/TopSpeed/Vehicles/Parsing/Build/Policy/PolicyValidation.cs
 #, csharp-format
 msgid "{0} must be between {1} and {2}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:169
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
 #, csharp-format
 msgid "{0} panel"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Online.cs:48
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Online.cs
 #, csharp-format
 msgid "{0} people are connected."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\VolumeShortcuts.cs:181
+#: top_speed_net/TopSpeed/Game/Settings/VolumeShortcuts.cs
 #, csharp-format
 msgid "{0} percent"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Multiplayer\Communicator\Runtime\MediaLocal.cs:270
+#: top_speed_net/TopSpeed/Game/Multiplayer/Communicator/Runtime/MediaLocal.cs
 #, csharp-format
 msgid "{0} percent."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Rules.cs:46
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Rules.cs
 #, csharp-format
 msgid "{0} player"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Options\Rules.cs:47
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Options/Rules.cs
 #, csharp-format
 msgid "{0} players"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:31
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultFmt.cs:42
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultFmt.cs
 #, csharp-format
 msgid "{0} second"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Text\SessionText.cs:32
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultFmt.cs:43
-#: D:\top_speed\top_speed_net\TopSpeed\Menu\Build\Options\Drive.cs:112
+#: top_speed_net/TopSpeed/Drive/Session/Text/SessionText.cs
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultFmt.cs
+#: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs
 #, csharp-format
 msgid "{0} seconds"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Mapping\Handler\Controller.cs:42
-#: D:\top_speed\top_speed_net\TopSpeed\Input\Mapping\Handler\Keyboard.cs:88
-#: D:\top_speed\top_speed_net\TopSpeed\Shortcuts\Mapping.cs:113
+#: top_speed_net/TopSpeed/Input/Mapping/Handler/Controller.cs
+#: top_speed_net/TopSpeed/Input/Mapping/Handler/Keyboard.cs
+#: top_speed_net/TopSpeed/Shortcuts/Mapping.cs
 #, csharp-format
 msgid "{0} set to {1}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Chat\HistoryText.cs:42
+#: top_speed_net/TopSpeed/Core/Multiplayer/Chat/HistoryText.cs
 #, csharp-format
 msgid "{0} was added to the current room."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Chat\HistoryText.cs:49
+#: top_speed_net/TopSpeed/Core/Multiplayer/Chat/HistoryText.cs
 #, csharp-format
 msgid "{0} was removed from the current room."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Menu\Players.cs:33
+#: top_speed_net/TopSpeed/Drive/Session/Systems/PlayerInfo.cs
+#, csharp-format
+msgid "{0} {1}"
+msgstr ""
+
+#: top_speed_net/TopSpeed/Drive/Session/Systems/PlayerInfo.cs
+#, csharp-format
+msgid "{0} {1} {2}"
+msgstr ""
+
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Menu/Players.cs
 #, csharp-format
 msgid "{0}, host"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Browser.cs:82
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Browser.cs
 #, csharp-format
 msgid "{0}, in progress"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Browser.cs:84
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Browser.cs
 #, csharp-format
 msgid "{0}, room is full"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Multiplayer\Rooms\Browser.cs:76
+#: top_speed_net/TopSpeed/Core/Multiplayer/Rooms/Browser.cs
 #, csharp-format
 msgid "{0}, {1} game with {2} people, maximum {3} players"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:74
+#: top_speed_net/TopSpeed/Drive/Session/Systems/PlayerInfo.cs
+#, csharp-format
+msgid "{0}, {1}, using {2}."
+msgstr ""
+
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 #, csharp-format
 msgid "{0}: completed in position {1} with a time of {2}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:68
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 #, csharp-format
 msgid "{0}: crossed in position {1} after {2}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:62
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 #, csharp-format
 msgid "{0}: finished in position {1} with {2}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:61
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:67
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Drive\Results\ResultCatalog.cs:73
+#: top_speed_net/TopSpeed/Game/Drive/Results/ResultCatalog.cs
 #, csharp-format
 msgid "{0}: position {1}, time {2}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Selection\VehicleSource.cs:64
-#: D:\top_speed\top_speed_net\TopSpeed\Core\Selection\VehicleSource.cs:91
+#: top_speed_net/TopSpeed/Core/Selection/VehicleSource.cs
 #, csharp-format
 msgid "{0}: {1}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Game\Settings\VolumeShortcuts.cs:161
+#: top_speed_net/TopSpeed/Game/Settings/VolumeShortcuts.cs
 #, csharp-format
 msgid "{0}: {1} percent"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Systems\PlayerInfo.cs:156
+#: top_speed_net/TopSpeed/Drive/Session/Systems/PlayerInfo.cs
 #, csharp-format
 msgid "{0}: {1}, using {2}."
-msgstr ""
-
-#: D:\top_speed\top_speed_net\TopSpeed\Drive\Session\Systems\PlayerInfo.cs:147
-#, csharp-format
-msgid "{0}: {1}, {2}, using {3}."
 msgstr ""

--- a/top_speed_net/languages/server/messages.pot
+++ b/top_speed_net/languages/server/messages.pot
@@ -8,1685 +8,1651 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-27 18:44+0300\n"
+"POT-Creation-Date: 2026-07-27 22:42-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Program.Args.cs:70
+#: top_speed_net/TopSpeed.Server/Program.Args.cs
 msgid "  --log <levels>          Alias for --log-level."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Program.Args.cs:71
+#: top_speed_net/TopSpeed.Server/Program.Args.cs
 msgid "  --log-file <path>       Output log file path (e.g. log.txt)."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Program.Args.cs:69
+#: top_speed_net/TopSpeed.Server/Program.Args.cs
 msgid ""
-"  --log-level <levels>    Comma-separated levels: error,warning,info,debug,"
-"all."
+"  --log-level <levels>    Comma-separated levels: "
+"error,warning,info,debug,all."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Program.Args.cs:67
+#: top_speed_net/TopSpeed.Server/Program.Args.cs
 msgid "  --max-players <number>  Max connected players (1-255)."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Program.Args.cs:68
+#: top_speed_net/TopSpeed.Server/Program.Args.cs
 msgid "  --motd <text>           Message of the day."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Program.Args.cs:66
+#: top_speed_net/TopSpeed.Server/Program.Args.cs
 msgid "  --port <number>         Server port (1-65535)."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Program.Args.cs:72
+#: top_speed_net/TopSpeed.Server/Program.Args.cs
 msgid "  -h, --help              Show this help."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Program.Args.cs:63
+#: top_speed_net/TopSpeed.Server/Program.Args.cs
 msgid "  TopSpeed.Server [options]"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:494
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "(empty)"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Control.cs:54
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Control.cs:76
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Control.cs
 msgid "A multiplayer race is not currently active."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Updates\Runner.cs:56
+#: top_speed_net/TopSpeed.Server/Updates/Runner.cs
 #, csharp-format
 msgid ""
 "A new update is available for the server. Your current server version is "
 "{0}. Available version: {1}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Messages.cs:105
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Players\Announcements.cs:12
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Players\Announcements.cs:27
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Messages.cs
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Players/Announcements.cs
 msgid "A player"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Host\GameStart.cs:32
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Host/GameStart.cs
 msgid "A race is already in progress."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Lifecycle.cs:122
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Lifecycle.cs
 #, csharp-format
 msgid "All loadouts ready: room={0} \"{1}\", starting race."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Protocol\RoomTexts.cs:7
+#: top_speed_net/TopSpeed.Shared/Protocol/RoomTexts.cs
 msgid "All players are ready. Starting game."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:211
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:442
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "Allow duplicate call signs"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:124
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "Available commands:"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Vehicles\Catalog\Data.cs:272
+#: top_speed_net/TopSpeed.Shared/Vehicles/Catalog/Data.cs
 msgid "BMW 3 Series"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:253
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:280
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:313
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "Back"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:209
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:418
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "Block repeated letters in call signs"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Bots\Setup.cs:18
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Bots\Setup.cs:20
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Bots/Setup.cs
 msgid "Bot"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Bots\Drive.cs:88
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Bots/Drive.cs
 #, csharp-format
 msgid "Bot crashed: room={0}, bot={1}, number={2}, y={3:0.0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Bots\Drive.cs:110
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Bots/Drive.cs
 #, csharp-format
 msgid "Bot finished: room={0}, bot={1}, number={2}, place={3}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Bots\Audio.cs:54
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Bots/Audio.cs
 #, csharp-format
 msgid ""
 "Bot horn triggered: bot={0}, number={1}, reason={2}, duration={3:0.00}s."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Bots\Phases.cs:150
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Bots/Phases.cs
 #, csharp-format
 msgid "Bot recovered and resumed: room={0}, bot={1}, number={2}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Bots\Phases.cs:103
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Bots/Phases.cs
 #, csharp-format
 msgid ""
-"Bot restarting after crash: room={0}, bot={1}, number={2}, restartDelay="
-"{3:0.00}s, startDelay={4:0.00}s."
+"Bot restarting after crash: room={0}, bot={1}, number={2}, "
+"restartDelay={3:0.00}s, startDelay={4:0.00}s."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Bots\Phases.cs:70
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Bots/Phases.cs
 #, csharp-format
 msgid "Bot started racing: room={0}, bot={1}, number={2}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Bots\Setup.cs:76
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Bots/Setup.cs
 #, csharp-format
 msgid "Bot {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Bots.cs:31
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Bots.cs
 msgid "Bots can only be added in race-with-bots rooms."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Bots.cs:76
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Bots.cs
 msgid "Bots can only be removed in race-with-bots rooms."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Bots.cs:25
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Bots.cs
 msgid "Cannot add bots while race setup or race is active."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Host\Rules.cs:67
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Host/Rules.cs
 msgid "Cannot change game rules while race setup or race is active."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Host\TrackSettings.cs:78
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Host/TrackSettings.cs
 msgid "Cannot change laps while race setup or race is active."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Host\Rules.cs:24
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Host/Rules.cs
 msgid "Cannot change player limit while race setup or race is active."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Host\TrackSettings.cs:24
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Host/TrackSettings.cs
 msgid "Cannot change track while race setup or race is active."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Bots.cs:70
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Bots.cs
 msgid "Cannot remove bots while race setup or race is active."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Host\Rules.cs:44
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Host/Rules.cs
 msgid "Cannot set lower than current players in room."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Updates\Runner.cs:59
+#: top_speed_net/TopSpeed.Server/Updates/Runner.cs
 msgid "Changes:"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:186
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:411
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "Check for updates on startup"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Updates\Runner.cs:30
+#: top_speed_net/TopSpeed.Server/Updates/Runner.cs
 msgid "Checking for update..."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:315
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "Choose server architecture:"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:282
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "Choose server language:"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:114
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 #, csharp-format
 msgid "Command '{0}' failed: {1}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:117
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "Command failed. Check server logs for details."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Messages.cs:91
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Messages.cs
 #, csharp-format
 msgid "Connection closed by server. Reason: {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Messages.cs:65
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Messages.cs
 msgid "Connection closed due to protocol error."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Messages.cs:77
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Messages.cs
 msgid "Connection closed."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Recovery.cs:134
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Recovery.cs
 #, csharp-format
 msgid "Connection established: playerId={0}, endpoint={1}, protocol={2}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Messages.cs:53
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Messages.cs:84
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Messages.cs
 msgid "Connection lost. Reconnect is available for a short time."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Packets\Core.cs:108
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Packets/Core.cs
 #, csharp-format
 msgid "Connection pending protocol negotiation: playerId={0}, endpoint={1}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Messages.cs:63
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Messages.cs
 msgid "Connection refused due to invalid protocol negotiation."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Handshake\Protocol.cs:196
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Messages.cs:61
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Handshake/Protocol.cs
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Messages.cs
 msgid "Connection refused due to protocol mismatch."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Messages.cs:87
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Messages.cs
 msgid "Connection rejected by transport policy."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Lifecycle.cs:250
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Lifecycle.cs
 #, csharp-format
 msgid ""
 "Connection removed: player={0}, endpoint={1}, room={2}, reason={3}, "
 "mappedReason={4}, mappedState={5}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Recovery.cs:86
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Recovery.cs
 #, csharp-format
 msgid "Connection resumed: playerId={0}, endpoint={1}, epoch={2}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Messages.cs:51
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Messages.cs
 msgid "Connection setup timed out before authentication."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Lifecycle.cs:190
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Lifecycle.cs
 #, csharp-format
 msgid ""
 "Connection suspended for reconnect: player={0}, endpoint={1}, room={2}, "
 "reason={3}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Updates\Runner.cs:150
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Updates\Runner.cs:152
+#: top_speed_net/TopSpeed.Server/Updates/Runner.cs
 #, csharp-format
 msgid "Could not launch updater: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Packages\CatalogState.cs:78
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Protocol\TrackPackages\Build\Identity.cs:26
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Packages/CatalogState.cs
+#: top_speed_net/TopSpeed.Shared/Protocol/TrackPackages/Build/Identity.cs
 msgid "Custom track"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Host\TrackSettings.cs:55
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Host/TrackSettings.cs
 msgid "Custom track package is not available on server."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:197
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:404
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "Custom tracks"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Host\Rules.cs:75
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Packages\UploadFlow.cs:16
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Host/Rules.cs
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Packages/UploadFlow.cs
 msgid "Custom tracks are disabled on this server."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Host\TrackSettings.cs:49
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Packages\UploadFlow.cs:21
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Host/TrackSettings.cs
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Packages/UploadFlow.cs
 msgid "Custom tracks are not enabled for this room."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:182
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "Discovery port"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:383
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 #, csharp-format
 msgid "Discovery port updated to {0}. Restart required for this change."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Discovery\DiscoveryService.cs:80
+#: top_speed_net/TopSpeed.Server/Network/Discovery/DiscoveryService.cs
 #, csharp-format
 msgid "Discovery receive failed: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Discovery\DiscoveryService.cs:41
+#: top_speed_net/TopSpeed.Server/Network/Discovery/DiscoveryService.cs
 #, csharp-format
 msgid "Discovery service listening on {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Discovery\DiscoveryService.cs:53
+#: top_speed_net/TopSpeed.Server/Network/Discovery/DiscoveryService.cs
 msgid "Discovery service stopped."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:52
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "Display server and protocol versions."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Updates\Service.cs:102
+#: top_speed_net/TopSpeed.Server/Updates/Service.cs
 #, csharp-format
 msgid "Download failed with status code {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Updates\Runner.cs:97
+#: top_speed_net/TopSpeed.Server/Updates/Runner.cs
 msgid "Download failed."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Updates\Service.cs:176
+#: top_speed_net/TopSpeed.Server/Updates/Service.cs
 #, csharp-format
 msgid "Download failed: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Updates\Service.cs:167
+#: top_speed_net/TopSpeed.Server/Updates/Service.cs
 msgid "Download timed out or was canceled."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Updates\Runner.cs:86
+#: top_speed_net/TopSpeed.Server/Updates/Runner.cs
 msgid "Downloading..."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Packets.cs:19
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Packets.cs
 #, csharp-format
 msgid "Dropped packet with invalid header from {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Packets.cs:28
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Packets.cs
 #, csharp-format
 msgid ""
 "Dropped packet with protocol version mismatch from {0}: received={1}, "
 "expected={2}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Packets.cs:75
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Packets.cs
 #, csharp-format
 msgid ""
 "Dropped pre-auth packet from unknown endpoint {0}: command={1}, sequence={2}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Packets.cs:47
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Packets.cs
 #, csharp-format
 msgid ""
 "Dropped stale packet epoch from {0}: command={1}, sequence={2}, "
 "expectedEpoch={3}, commandEpoch={4}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Packets.cs:61
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Packets.cs
 #, csharp-format
 msgid ""
-"Dropped stale packet from prior epoch: endpoint={0}, command={1}, sequence="
-"{2}, activeEpoch={3}."
+"Dropped stale packet from prior epoch: endpoint={0}, command={1}, "
+"sequence={2}, activeEpoch={3}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Vehicles\Catalog\Data.cs:366
+#: top_speed_net/TopSpeed.Shared/Vehicles/Catalog/Data.cs
 msgid "Ducati Panigale V4"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Completion.cs:83
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Completion.cs
 #, csharp-format
 msgid "Duplicate finish ignored: room={0}, player={1}, number={2}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:74
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 #, csharp-format
 msgid "Duplicate room id '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:62
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 #, csharp-format
 msgid "Duplicate segment id '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:79
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 #, csharp-format
 msgid "Duplicate sound id '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:69
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 #, csharp-format
 msgid "Duplicate weather id '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Localization\Languages.cs:28
+#: top_speed_net/TopSpeed.Server/Localization/Languages.cs
 msgid "English (Original)"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:375
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "Enter discovery port (1-65535):"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:424
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 #, csharp-format
 msgid "Enter max call sign length (1-{0}):"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:388
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "Enter max players (1-255):"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:346
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 #, csharp-format
 msgid "Enter message of the day (max {0} chars, empty clears value):"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Input.cs:67
+#: top_speed_net/TopSpeed.Server/Commands/Input.cs
 msgid "Enter option number:"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:362
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "Enter server port (1-65535):"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Issues\Issue.cs:22
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Issues/Issue.cs
 msgid "Error"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Packets\Core.cs:75
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Packets/Core.cs
 #, csharp-format
 msgid "Failed to parse {0} packet from {1}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Config\SettingsStore.cs:40
+#: top_speed_net/TopSpeed.Server/Config/SettingsStore.cs
 #, csharp-format
 msgid "Failed to read server settings, using defaults: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Config\SettingsStore.cs:61
+#: top_speed_net/TopSpeed.Server/Config/SettingsStore.cs
 #, csharp-format
 msgid "Failed to save server settings: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Transport\ServerTransport.cs:121
+#: top_speed_net/TopSpeed.Server/Network/Transport/ServerTransport.cs
 #, csharp-format
 msgid "Failed to start transport on port {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:194
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "Feature options:"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:184
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "Features"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Vehicles\Catalog\Data.cs:118
+#: top_speed_net/TopSpeed.Shared/Vehicles/Catalog/Data.cs
 msgid "Fiat 500"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Finish.cs:33
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Finish.cs
 #, csharp-format
 msgid "Finish ignored: room={0}, player={1}, number={2}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Finish.cs:49
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Finish.cs
 #, csharp-format
 msgid ""
 "Finish recorded: room={0}, player={1}, number={2}, place={3}, timeMs={4}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Vehicles\Catalog\Data.cs:178
+#: top_speed_net/TopSpeed.Shared/Vehicles/Catalog/Data.cs
 msgid "Ford Mustang 1969"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Membership\CreateJoin.cs:47
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Membership/CreateJoin.cs
 msgid "Game room not found."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Membership\CreateJoin.cs:17
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Membership/CreateJoin.cs
 #, csharp-format
 msgid "Game {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:156
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 msgid "Humidity must be between 0 and 1."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Packets\Core.cs:34
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Packets/Core.cs
 #, csharp-format
 msgid ""
 "Ignored client heartbeat with mismatched player id from {0}: expected={1}, "
 "received={2}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Packets\Core.cs:44
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Packets/Core.cs
 #, csharp-format
 msgid ""
 "Ignored client heartbeat with mismatched session id from {0}: expected={1}, "
 "received={2}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Handshake\Protocol.cs:29
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Handshake/Protocol.cs
 #, csharp-format
 msgid "Ignoring pre-identification command from {0}: {1}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Handshake\Protocol.cs:50
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Handshake/Protocol.cs
 #, csharp-format
 msgid "Ignoring pre-protocol command from {0}: {1}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Packets.cs:97
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Packets.cs
 #, csharp-format
 msgid "Ignoring unknown packet command {0} from {1}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Program.Args.cs:154
+#: top_speed_net/TopSpeed.Server/Program.Args.cs
 msgid "Invalid --max-players value. Using configured max players."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Program.Args.cs:146
+#: top_speed_net/TopSpeed.Server/Program.Args.cs
 msgid "Invalid --port value. Using configured port."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:111
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 #, csharp-format
 msgid "Invalid ambience value '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:258
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:115
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 #, csharp-format
 msgid "Invalid boolean '{0}' for key '{1}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:103
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 #, csharp-format
 msgid "Invalid command \"{0}\". Type \"help\" for the list of commands."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Input.cs:72
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Input.cs:103
+#: top_speed_net/TopSpeed.Server/Commands/Input.cs
 msgid "Invalid input. Enter a valid number."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Updates\Runner.cs:214
+#: top_speed_net/TopSpeed.Server/Updates/Runner.cs
 msgid "Invalid input. Enter y or n."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:292
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Invalid numeric value '{0}' for key '{1}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Input.cs:84
+#: top_speed_net/TopSpeed.Server/Commands/Input.cs
 msgid "Invalid option number."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:109
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Invalid pit value '{0}'. Use pit_entry or pit_exit."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Handshake\Protocol.cs:37
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Handshake/Protocol.cs
 msgid "Invalid player identification packet."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Handshake\Protocol.cs:58
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Handshake/Protocol.cs
 msgid "Invalid protocol handshake packet."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Handshake\Protocol.cs:88
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Handshake/Protocol.cs
 #, csharp-format
 msgid ""
 "Invalid protocol handshake. Reported protocol version {0} is outside "
 "declared supported range {1}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Handshake\Protocol.cs:77
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Handshake/Protocol.cs
 msgid "Invalid protocol range in handshake packet."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:307
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Invalid room override value '{0}' for key '{1}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:193
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Invalid room value '{0}' for key '{1}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:60
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Invalid segment height '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:44
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Invalid segment length '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:37
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Invalid segment noise '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:30
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Invalid segment surface '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:23
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Invalid segment type '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:53
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Invalid segment width '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Protocol\TrackPackages\Build\Assets.cs:65
+#: top_speed_net/TopSpeed.Shared/Protocol/TrackPackages/Build/Assets.cs
 #, csharp-format
 msgid "Invalid sound asset path: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:251
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Invalid sound random mode '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:213
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Invalid sound type '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Packages\UploadFlow.cs:26
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Packages/UploadFlow.cs
 msgid "Invalid track package upload request."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Host\TrackSettings.cs:30
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Host/TrackSettings.cs
 msgid "Invalid track selection."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:285
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Invalid vector '{0}' for key '{1}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:125
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Invalid weather kind '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:77
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Invalid weather transition seconds '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:134
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:140
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Invalid weather value '{0}' for key '{1}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Membership\CreateJoin.cs:61
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Membership/CreateJoin.cs
 #, csharp-format
 msgid "Join denied: player={0}, room={1}, raceStarted={2}, preparing={3}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Vehicles\Catalog\Data.cs:336
+#: top_speed_net/TopSpeed.Shared/Vehicles/Catalog/Data.cs
 msgid "Kawasaki Ninja ZX-10R"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:101
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 #, csharp-format
 msgid "Key '{0}' is missing a value."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Vehicles\Catalog\Data.cs:240
+#: top_speed_net/TopSpeed.Shared/Vehicles/Catalog/Data.cs
 msgid "Lamborghini Aventador"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:179
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "Language"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Host\TrackSettings.cs:84
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Host/TrackSettings.cs
 msgid "Laps must be between 1 and 500."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:51
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "List connected players and protocol versions."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Runtime\Lifecycle.cs:72
+#: top_speed_net/TopSpeed.Server/Network/Runtime/Lifecycle.cs
 #, csharp-format
 msgid "LiteNetLib network error: endpoint={0}, socketError={1}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Runtime\Lifecycle.cs:120
+#: top_speed_net/TopSpeed.Server/Network/Runtime/Lifecycle.cs
 #, csharp-format
 msgid "LiteNetLib peer address changed: old={0}, new={1}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Transport\ServerTransport.cs:136
+#: top_speed_net/TopSpeed.Server/Network/Transport/ServerTransport.cs
 #, csharp-format
 msgid "LiteNetLib poll failed: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Transport\ServerTransport.cs:186
+#: top_speed_net/TopSpeed.Server/Network/Transport/ServerTransport.cs
 #, csharp-format
 msgid "LiteNetLib send failed: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Transport\ServerTransport.cs:152
+#: top_speed_net/TopSpeed.Server/Network/Transport/ServerTransport.cs
 #, csharp-format
 msgid "LiteNetLib stop failed: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Transport\ServerTransport.cs:124
+#: top_speed_net/TopSpeed.Server/Network/Transport/ServerTransport.cs
 #, csharp-format
 msgid "LiteNetLib transport listening on {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Transport\ServerTransport.cs:159
+#: top_speed_net/TopSpeed.Server/Network/Transport/ServerTransport.cs
 msgid "LiteNetLib transport stopped."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Program.cs:42
+#: top_speed_net/TopSpeed.Server/Program.cs
 #, csharp-format
 msgid "Logging enabled. Levels: {0}. File: {1}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:87
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 msgid "Malformed line. Expected '[section]' or 'key = value'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:53
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "Manually check for server updates."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:183
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "Max players"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:397
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 #, csharp-format
 msgid "Max players updated to {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:210
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "Maximum call sign length"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:435
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 #, csharp-format
 msgid "Maximum call sign length updated to {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Vehicles\Catalog\Data.cs:304
+#: top_speed_net/TopSpeed.Shared/Vehicles/Catalog/Data.cs
 msgid "Mercedes Sprinter"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:180
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "Message of the day"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:357
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "Message of the day updated."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Vehicles\Catalog\Data.cs:148
+#: top_speed_net/TopSpeed.Shared/Vehicles/Catalog/Data.cs
 msgid "Mini Cooper S"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Protocol\TrackPackages\Build\Assets.cs:82
+#: top_speed_net/TopSpeed.Shared/Protocol/TrackPackages/Build/Assets.cs
 #, csharp-format
 msgid "Missing sound asset file: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:187
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "Moderation"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:206
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "Moderation options:"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Vehicles\Catalog\Data.cs:54
+#: top_speed_net/TopSpeed.Shared/Vehicles/Catalog/Data.cs
 msgid "Nissan GT-R Nismo"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Updates\Runner.cs:62
+#: top_speed_net/TopSpeed.Server/Updates/Runner.cs
 msgid "No changes were listed for this update."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:273
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "No languages are available."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Host\GameStart.cs:25
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Host/GameStart.cs
 #, csharp-format
 msgid "Not enough players. {0} required to start."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Host\Rules.cs:37
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Host/Rules.cs
 msgid "One-on-one rooms always allow a maximum of 2 players."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Access.cs:34
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Access.cs
 msgid "Only host can do this."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:50
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "Open server options menu."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Program.Args.cs:65
+#: top_speed_net/TopSpeed.Server/Program.Args.cs
 msgid "Options:"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Membership\CreateJoin.cs:79
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Membership/CreateJoin.cs
 #, csharp-format
 msgid "Player joined room: room={0} \"{1}\", player={2}, participants={3}/{4}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Membership\Leave.cs:106
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Membership/Leave.cs
 #, csharp-format
 msgid ""
 "Player left room: room={0} \"{1}\", player={2}, notify={3}, roomClosed={4}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Host\Rules.cs:31
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Host/Rules.cs
 msgid "Player limit must be between 2 and 10."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Ready.cs:42
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Ready.cs
 #, csharp-format
 msgid ""
 "Player ready: room={0}, player={1}, car={2}, automatic={3}, ready={4}/{5}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Players.cs:136
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Players.cs
 #, csharp-format
 msgid "Player state transition from data: room={0}, player={1}, {2} -> {3}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Players.cs:42
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Players.cs
 #, csharp-format
 msgid "Player state transition: room={0}, player={1}, {2} -> {3} (packet={4})."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Runtime\Admin.cs:124
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Notify\Room.cs:169
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Players.cs:58
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Membership\CreateJoin.cs:145
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Messages.cs:38
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Messages.cs:78
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Online.cs:89
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Ready.cs:93
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Players\Core.cs:54
+#: top_speed_net/TopSpeed.Server/Network/Runtime/Admin.cs
+#: top_speed_net/TopSpeed.Server/Network/Services/Notify/Room.cs
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Players.cs
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Membership/CreateJoin.cs
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Messages.cs
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Online.cs
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Ready.cs
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Players/Core.cs
 #, csharp-format
 msgid "Player {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Vehicles\Catalog\Data.cs:86
+#: top_speed_net/TopSpeed.Shared/Vehicles/Catalog/Data.cs
 msgid "Porsche 911 GT3 RS"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:93
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 #, csharp-format
 msgid "Property '{0}' is outside any section."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Handshake\Protocol.cs:211
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Handshake/Protocol.cs
 msgid "Protocol compatibility verified."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Program.cs:48
+#: top_speed_net/TopSpeed.Server/Program.cs
 #, csharp-format
 msgid "Protocol current: {0}. Supported: {1}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Handshake\Protocol.cs:183
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Handshake/Protocol.cs
 msgid "Protocol negotiation failed."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Handshake\Protocol.cs:187
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Handshake/Protocol.cs
 #, csharp-format
 msgid ""
 "Protocol rejected: player={0}, endpoint={1}, reportedProtocolVersion={2}, "
 "clientSupported={3}, serverSupported={4}, reason={5}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Handshake\Protocol.cs:111
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Handshake/Protocol.cs
 #, csharp-format
 msgid ""
 "Protocol rejected: player={0}, endpoint={1}, reportedProtocolVersion={2}, "
 "clientSupported={3}, serverSupported={4}, status={5}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:157
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 #, csharp-format
 msgid "Protocol supported range: {0} to {1}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:156
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Program.cs:55
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
+#: top_speed_net/TopSpeed.Server/Program.cs
 #, csharp-format
 msgid "Protocol version: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Lifecycle.cs:291
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Lifecycle.cs
 #, csharp-format
 msgid "Race completion invariant failed before emit: room={0}, reason={1}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Finish.cs:59
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Finish.cs
 #, csharp-format
 msgid "Race completion pending: room={0}, finished={1}/{2}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Completion.cs:58
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Completion.cs
 #, csharp-format
 msgid "Race completion ready: room={0}, all active participants finished."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Completion.cs:37
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Completion.cs
 #, csharp-format
 msgid "Race completion ready: room={0}, no active participants remain."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Control.cs:43
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Control.cs
 msgid "Race preparation is not currently active."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Lifecycle.cs:100
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Lifecycle.cs
 #, csharp-format
 msgid ""
-"Race prepare cancelled after loadout: room={0} \"{1}\", active={2}, minStart="
-"{3}."
+"Race prepare cancelled after loadout: room={0} \"{1}\", active={2}, "
+"minStart={3}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Lifecycle.cs:63
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Lifecycle.cs
 #, csharp-format
 msgid ""
 "Race prepare cancelled: room={0} \"{1}\", participants={2}, minStart={3}, "
 "capacity={4}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Host\GameStart.cs:57
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Host/GameStart.cs
 #, csharp-format
 msgid ""
-"Race prepare started: room={0} \"{1}\", requestedBy={2}, humans={3}, bots="
-"{4}, capacity={5}, minStart={6}."
+"Race prepare started: room={0} \"{1}\", requestedBy={2}, humans={3}, "
+"bots={4}, capacity={5}, minStart={6}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Runtime\Lifecycle.cs:19
+#: top_speed_net/TopSpeed.Server/Network/Runtime/Lifecycle.cs
 msgid "Race server started."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Runtime\Lifecycle.cs:36
+#: top_speed_net/TopSpeed.Server/Network/Runtime/Lifecycle.cs
 msgid "Race server stopped."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Ready.cs:21
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Ready.cs:67
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Ready.cs
 msgid "Race setup has not started yet."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Host\GameStart.cs:38
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Host/GameStart.cs
 msgid "Race setup is already in progress."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Snapshots\StateSnapshots.cs:31
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Snapshots/StateSnapshots.cs
 #, csharp-format
 msgid "Race snapshot send: room={0}, delivery={1}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Lifecycle.cs:61
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Lifecycle.cs
 msgid "Race start cancelled because there are not enough players."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Lifecycle.cs:98
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Lifecycle.cs
 msgid "Race start cancelled because there are not enough ready players."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Lifecycle.cs:269
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Lifecycle.cs
 #, csharp-format
 msgid ""
 "Race started: room={0} \"{1}\", track={2}, laps={3}, humans={4}, bots={5}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Lifecycle.cs:346
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Lifecycle.cs
 #, csharp-format
 msgid "Race stopped: room={0} \"{1}\", results={2}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Messages.cs:55
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Messages.cs
 msgid ""
 "Reconnect denied because the remote IP does not match the original session."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Messages.cs:57
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Messages.cs
 msgid "Reconnect denied because the resume token is invalid."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Messages.cs:59
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Messages.cs
 msgid "Reconnect window expired."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Packets\Core.cs:96
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Packets/Core.cs
 #, csharp-format
 msgid "Refused connection from {0}: server is full."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Bots.cs:97
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Bots.cs
 #, csharp-format
 msgid "Removed bot {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Recovery.cs:168
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Recovery.cs
 #, csharp-format
 msgid ""
 "Resume fallback accepted as new session: pendingPlayerId={0}, endpoint={1}, "
 "reason={2}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Bots.cs:20
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Bots.cs
 #, csharp-format
 msgid ""
 "Room add-bot denied: room={0}, player={1}, raceStarted={2}, preparing={3}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Membership\Leave.cs:115
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Membership/Leave.cs
 #, csharp-format
 msgid "Room closed: room={0} \"{1}\", reason=last_participant_left."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Membership\CreateJoin.cs:35
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Membership/CreateJoin.cs
 #, csharp-format
 msgid "Room created: room={0} \"{1}\", host={2}, type={3}, playersToStart={4}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Host\Rules.cs:62
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Host/Rules.cs
 #, csharp-format
 msgid ""
 "Room game-rules change denied: room={0}, player={1}, raceStarted={2}, "
 "preparing={3}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Numbering.cs:91
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Numbering.cs
 #, csharp-format
 msgid "Room game-start numbers shuffled: room={0}, players={1}, bots={2}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Host\TrackSettings.cs:73
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Host/TrackSettings.cs
 #, csharp-format
 msgid ""
-"Room laps change denied: room={0}, player={1}, raceStarted={2}, preparing="
-"{3}."
+"Room laps change denied: room={0}, player={1}, raceStarted={2}, "
+"preparing={3}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Numbering.cs:47
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Numbering.cs
 #, csharp-format
 msgid "Room numbers reassigned: room={0}, players={1}, bots={2}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Host\Rules.cs:19
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Host/Rules.cs
 #, csharp-format
 msgid ""
 "Room player-limit change denied: room={0}, player={1}, raceStarted={2}, "
 "preparing={3}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Bots.cs:65
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Bots.cs
 #, csharp-format
 msgid ""
 "Room remove-bot denied: room={0}, player={1}, raceStarted={2}, preparing={3}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Host\TrackSettings.cs:19
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Host/TrackSettings.cs
 #, csharp-format
 msgid ""
-"Room track change denied: room={0}, player={1}, raceStarted={2}, preparing="
-"{3}."
+"Room track change denied: room={0}, player={1}, raceStarted={2}, "
+"preparing={3}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:54
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 #, csharp-format
 msgid "Section '{0}' requires an id."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:190
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 #, csharp-format
 msgid ""
 "Segment '{0}' references room '{1}', but no matching [room:{1}] section or "
 "preset exists."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:203
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 #, csharp-format
 msgid ""
 "Segment '{0}' references sound source '{1}', but no matching [sound:{1}] "
 "section exists."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:215
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 #, csharp-format
 msgid ""
 "Segment '{0}' references weather profile '{1}', but no matching [weather:"
 "{1}] section exists."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:46
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Segment length '{0}' is below minimum {1} and will be clamped."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:87
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 msgid "Segment room id cannot be empty."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:100
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 msgid "Segment sound source list cannot be empty."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:68
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 msgid "Segment weather profile id cannot be empty."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:185
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "Server architecture"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:339
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 #, csharp-format
 msgid "Server architecture remains {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:333
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 #, csharp-format
 msgid "Server architecture set to {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Runtime\Lifecycle.cs:193
+#: top_speed_net/TopSpeed.Server/Network/Runtime/Lifecycle.cs
 #, csharp-format
 msgid "Server command failed: kind={0}, sequence={1}, reason={2}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:71
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid ""
 "Server command interface ready. Type \"help\" to get the list of commands."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Program.cs:79
+#: top_speed_net/TopSpeed.Server/Program.cs
 #, csharp-format
 msgid ""
-"Server configuration: port={0}, discoveryPort={1}, maxPlayers={2}, features."
-"custom_tracks={3}, features.text_chat={4}, features.voice_chat={5}, "
+"Server configuration: port={0}, discoveryPort={1}, maxPlayers={2}, "
+"features.custom_tracks={3}, features.text_chat={4}, features.voice_chat={5}, "
 "moderation.maxNameLength={6}, moderation.blockRepeatedLettersInName={7}, "
 "moderation.allowDuplicateNames={8}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Updates\Runner.cs:50
+#: top_speed_net/TopSpeed.Server/Updates/Runner.cs
 msgid "Server is up-to-date."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:304
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 #, csharp-format
 msgid "Server language remains {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:300
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 #, csharp-format
 msgid "Server language set to {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:176
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "Server options:"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:181
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "Server port"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:370
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 #, csharp-format
 msgid "Server port updated to {0}. Restart required for this change."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Program.cs:54
+#: top_speed_net/TopSpeed.Server/Program.cs
 #, csharp-format
 msgid "Server release: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Program.cs:47
+#: top_speed_net/TopSpeed.Server/Program.cs
 #, csharp-format
 msgid "Server release: {0}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Program.cs:104
+#: top_speed_net/TopSpeed.Server/Program.cs
 msgid "Server started. Press Ctrl+C to stop."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Program.cs:111
+#: top_speed_net/TopSpeed.Server/Program.cs
 msgid "Server stopped."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Updates\Runner.cs:42
+#: top_speed_net/TopSpeed.Server/Updates/Runner.cs
 #, csharp-format
 msgid "Server update check failed: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Updates\Runner.cs:100
+#: top_speed_net/TopSpeed.Server/Updates/Runner.cs
 #, csharp-format
 msgid "Server update download failed: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:155
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 #, csharp-format
 msgid "Server version: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:49
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "Show available server commands."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:54
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "Shutdown the server."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Packages\LocalPackages.cs:50
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Packages/LocalPackages.cs
 #, csharp-format
 msgid "Skipping server track package '{0}': {1}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:237
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 #, csharp-format
 msgid ""
 "Sound '{0}' references end_area '{1}', but no matching segment id exists."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:226
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 #, csharp-format
 msgid ""
 "Sound '{0}' references start_area '{1}', but no matching segment id exists."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Protocol\TrackPackages\Build\Assets.cs:76
+#: top_speed_net/TopSpeed.Shared/Protocol/TrackPackages/Build/Assets.cs
 #, csharp-format
 msgid "Sound asset path escapes the track folder: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:234
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid ""
 "Sound key '{0}' contains invalid path '{1}'. Paths must be track-relative."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:220
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid ""
 "Sound key '{0}' must be a track-relative path and cannot escape the track "
 "folder."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:228
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:244
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Sound list for '{0}' cannot be empty."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:92
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:226
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:284
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:317
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:350
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:364
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:377
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:390
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:429
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "Standard input is no longer available. Server commands are disabled."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:65
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "Standard input is not available. Server commands are disabled."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Updates\Runner.cs:77
+#: top_speed_net/TopSpeed.Server/Updates/Runner.cs
 msgid "Standard input is not available. Update download was skipped."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Lifecycle.cs:283
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Lifecycle.cs
 #, csharp-format
 msgid "Stopping race: room={0}, active={1}, trackedResults={2}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:198
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:449
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "Text chat"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Moderation\TextChat.cs:20
+#: top_speed_net/TopSpeed.Server/Moderation/TextChat.cs
 msgid "Text chat is disabled on this server."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Control.cs:64
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Control.cs
 msgid "The current game is already paused."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Control.cs:65
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Control.cs
 msgid "The current game is not paused."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Protocol\TrackPackages\Build\Errors.cs:13
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Protocol\TrackPackages\Build\Errors.cs:19
+#: top_speed_net/TopSpeed.Shared/Protocol/TrackPackages/Build/Errors.cs
 msgid "The selected custom track is invalid."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Messages.cs:46
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Messages.cs
 msgid "The server closed the connection."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:148
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Runtime\Admin.cs:61
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Messages.cs:75
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
+#: top_speed_net/TopSpeed.Server/Network/Runtime/Admin.cs
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Messages.cs
 msgid "The server will be shut down immediately by the host."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Updates\Service.cs:38
+#: top_speed_net/TopSpeed.Server/Updates/Service.cs
 msgid "The update info file could not be read."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Updates\Service.cs:42
+#: top_speed_net/TopSpeed.Server/Updates/Service.cs
 msgid "The update info file has an invalid server version format."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Protocol\RoomTexts.cs:9
+#: top_speed_net/TopSpeed.Shared/Protocol/RoomTexts.cs
 msgid "There are no bots to remove."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Messages.cs:73
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Messages.cs
 msgid "This call sign is already in use on this server."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Moderation\Names.cs:83
+#: top_speed_net/TopSpeed.Server/Moderation/Names.cs
 msgid ""
 "This call sign is already in use on this server. Please choose a different "
 "name."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Membership\CreateJoin.cs:66
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Membership/CreateJoin.cs
 msgid "This game room is currently in progress."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Protocol\RoomTexts.cs:8
+#: top_speed_net/TopSpeed.Shared/Protocol/RoomTexts.cs
 msgid "This game room is unavailable because it is full."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Messages.cs:67
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Packets\Core.cs:94
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Recovery.cs:162
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Messages.cs
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Packets/Core.cs
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Recovery.cs
 msgid "This server is full."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Runtime\Lifecycle.cs:13
+#: top_speed_net/TopSpeed.Server/Network/Runtime/Lifecycle.cs
 msgid "TopSpeed Server"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Program.cs:49
+#: top_speed_net/TopSpeed.Server/Program.cs
 msgid "TopSpeed Server starting."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Program.cs:53
+#: top_speed_net/TopSpeed.Server/Program.cs
 msgid "TopSpeed Server starting..."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Program.cs:109
+#: top_speed_net/TopSpeed.Server/Program.cs
 msgid "TopSpeed Server stopped."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Program.Args.cs:62
+#: top_speed_net/TopSpeed.Server/Program.Args.cs
 msgid "TopSpeed.Server usage:"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Vehicles\Catalog\Data.cs:208
+#: top_speed_net/TopSpeed.Shared/Vehicles/Catalog/Data.cs
 msgid "Toyota Camry"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:170
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 msgid ""
 "Track [meta] must define a weather profile reference, for example 'weather = "
 "default'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Host\TrackSettings.cs:39
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Host/TrackSettings.cs
 msgid "Track cannot be empty."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Protocol\TrackPackages\Build\Payload.cs:23
+#: top_speed_net/TopSpeed.Shared/Protocol/TrackPackages/Build/Payload.cs
 msgid "Track data is missing."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:177
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 #, csharp-format
 msgid ""
 "Track default weather profile '{0}' does not match any [weather:{0}] section."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Parser.cs:31
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Parser.cs:55
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Parser.cs
 #, csharp-format
 msgid "Track file not found: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:157
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 msgid "Track must include at least one [segment:<id>] section."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Packages\UploadFlow.cs:33
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Packages/UploadFlow.cs
 msgid "Track package already exists on server."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Packages\UploadFlow.cs:101
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Packages/UploadFlow.cs
 msgid "Track package hash mismatch."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Packages\UploadFlow.cs:67
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Packages/UploadFlow.cs
 msgid "Track package upload exceeded declared size."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Packages\UploadFlow.cs:88
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Packages/UploadFlow.cs
 msgid "Track package upload is incomplete."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Packages\UploadFlow.cs:148
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Packages/UploadFlow.cs
 msgid "Track package upload ownership changed."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Packages\UploadFlow.cs:115
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Packages/UploadFlow.cs
 msgid "Track package uploaded successfully."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Parser.cs:65
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Parser.cs
 #, csharp-format
 msgid "Track path must point to a .tsm file inside a track folder: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:163
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 msgid ""
 "Track sets 'pit_area = false' but also defines pit entry/exit segments; "
 "pitting is disabled and the pit segments are ignored."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Protocol\TrackPackages\Build\Assets.cs:23
+#: top_speed_net/TopSpeed.Shared/Protocol/TrackPackages/Build/Assets.cs
 msgid "Track source path is missing, so sound assets cannot be resolved."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Lifecycle.cs:130
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Lifecycle.cs
 #, csharp-format
 msgid ""
-"Transport disconnect observed: player={0}, endpoint={1}, transportReason="
-"{2}, socketError={3}, mappedReason={4}, mappedState={5}."
+"Transport disconnect observed: player={0}, endpoint={1}, "
+"transportReason={2}, socketError={3}, mappedReason={4}, mappedState={5}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Protocol\TrackPackages\Build\Assets.cs:30
+#: top_speed_net/TopSpeed.Shared/Protocol/TrackPackages/Build/Assets.cs
 msgid "Unable to resolve custom track folder path."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Messages.cs:89
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Messages.cs
 msgid "Unable to resolve server host."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Recovery.cs:147
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Recovery.cs
 msgid "Unable to resume the previous multiplayer session."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Packages\UploadFlow.cs:111
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Packages/UploadFlow.cs
 msgid "Unable to store track package on server."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Control.cs:34
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Control.cs
 msgid "Unknown race control request."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:198
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Unknown room key '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:186
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Unknown room preset '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Validate.cs:46
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Validate.cs
 #, csharp-format
 msgid "Unknown section '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:117
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Unknown segment key '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:297
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Unknown sound key '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Updates\Service.cs:247
+#: top_speed_net/TopSpeed.Server/Updates/Service.cs
 msgid "Unknown update error."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:175
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Unknown weather key '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Updates\Runner.cs:39
+#: top_speed_net/TopSpeed.Server/Updates/Runner.cs
 msgid "Update check failed."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Updates\Service.cs:77
+#: top_speed_net/TopSpeed.Server/Updates/Service.cs
 #, csharp-format
 msgid "Update check failed: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Updates\Service.cs:73
+#: top_speed_net/TopSpeed.Server/Updates/Service.cs
 msgid "Update check timed out."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Updates\Service.cs:56
+#: top_speed_net/TopSpeed.Server/Updates/Service.cs
 #, csharp-format
 msgid "Update package '{0}' was not found in the latest release."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Updates\Runner.cs:119
+#: top_speed_net/TopSpeed.Server/Updates/Runner.cs
 #, csharp-format
 msgid "Updater not found: {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Input.cs:129
+#: top_speed_net/TopSpeed.Server/Commands/Input.cs
 msgid "Value cannot be empty."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Input.cs:135
+#: top_speed_net/TopSpeed.Server/Commands/Input.cs
 #, csharp-format
 msgid "Value is too long. Maximum length is {0} characters."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Input.cs:109
+#: top_speed_net/TopSpeed.Server/Commands/Input.cs
 #, csharp-format
 msgid "Value must be between {0} and {1}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:199
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:456
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "Voice chat"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Lifecycle.cs:79
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Lifecycle.cs
 #, csharp-format
 msgid ""
 "Waiting for loadouts: room={0}, ready={1}, skipped={2}, totalHumans={3}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Lifecycle.cs:112
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Lifecycle.cs
 #, csharp-format
 msgid ""
 "Waiting for track package readiness: room={0}, trackHash={1}, ready={2}/{3}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Issues\Issue.cs:21
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Issues/Issue.cs
 msgid "Warning"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:148
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:152
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:160
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:164
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Weather key '{0}' must be greater than zero."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:170
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 #, csharp-format
 msgid "Weather key '{0}' must be non-negative."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:79
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 msgid "Weather transition seconds must be finite and non-negative."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Updates\Runner.cs:75
+#: top_speed_net/TopSpeed.Server/Updates/Runner.cs
 msgid "Would you like to download the update? (y/n)"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Vehicles\Catalog\Data.cs:396
+#: top_speed_net/TopSpeed.Shared/Vehicles/Catalog/Data.cs
 msgid "Yamaha YZF-R1"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Access.cs:17
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Access.cs:27
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Membership\Leave.cs:16
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Messages.cs:73
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Ready.cs:15
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Ready.cs:61
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Access.cs
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Membership/Leave.cs
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Messages.cs
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Ready.cs
 msgid "You are not in a game room."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Ready.cs:27
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Ready.cs:73
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Ready.cs
 msgid "You are not in this game room."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Membership\Leave.cs:98
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Lifecycle.cs:210
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Membership/Leave.cs
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Lifecycle.cs
 msgid "You are now host of this room."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Ready.cs:32
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Ready.cs:78
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Ready.cs
 msgid "You are temporarily disconnected from this game room."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Messages.cs:69
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Messages.cs
 msgid "Your call sign is too long for this server."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Moderation\Names.cs:66
+#: top_speed_net/TopSpeed.Server/Moderation/Names.cs
 #, csharp-format
 msgid ""
 "Your call sign is too long. The server does not allow names exceeding {0} "
 "characters. Please try a different name."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Moderation\Names.cs:74
+#: top_speed_net/TopSpeed.Server/Moderation/Names.cs
 msgid ""
 "Your call sign was rejected because it contains a letter repeated too many "
 "times in a row. Please try a different name."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Messages.cs:71
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Messages.cs
 msgid "Your call sign was rejected by moderation policy."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Handshake\Protocol.cs:227
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Handshake/Protocol.cs
 #, csharp-format
 msgid ""
 "Your client protocol version is out-of-date: {0}. This server supports "
 "protocol versions {1}. Please update your client."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Handshake\Protocol.cs:232
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Handshake/Protocol.cs
 #, csharp-format
 msgid ""
 "Your client protocol version is too new: {0} and does not match this server "
@@ -1694,14 +1660,14 @@ msgid ""
 "update."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Handshake\Protocol.cs:237
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Handshake/Protocol.cs
 #, csharp-format
 msgid ""
 "Your client protocol version is {0}. This server supports protocol versions "
 "{1}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Handshake\Protocol.cs:215
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Handshake/Protocol.cs
 #, csharp-format
 msgid ""
 "Your client protocol version {0} is newer than this server protocol version "
@@ -1709,7 +1675,7 @@ msgid ""
 "features may behave differently or may not work at all."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Handshake\Protocol.cs:221
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Handshake/Protocol.cs
 #, csharp-format
 msgid ""
 "Your client protocol version {0} is older than this server protocol version "
@@ -1717,220 +1683,218 @@ msgid ""
 "features may behave differently or may not work at all."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Tracks\TrackLoader.cs:58
+#: top_speed_net/TopSpeed.Server/Tracks/TrackLoader.cs
 #, csharp-format
 msgid "[TrackLoader] Failed to load '{0}'."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Tracks\TrackLoader.cs:64
+#: top_speed_net/TopSpeed.Server/Tracks/TrackLoader.cs
 #, csharp-format
 msgid "[TrackLoader] Failed to load '{0}':"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Messages.cs:81
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Messages.cs
 #, csharp-format
 msgid "[room]: {0} says: {1}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Program.Args.cs:80
+#: top_speed_net/TopSpeed.Server/Program.Args.cs
 msgid "all"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Runtime\Admin.cs:102
+#: top_speed_net/TopSpeed.Server/Network/Runtime/Admin.cs
 #, csharp-format
 msgid ""
-"authoritative players={0}, rooms={1}, stale_epoch_drops={2}, replay_gaps="
-"{3}, epoch_rejects={4}, heartbeat_suspicions={5}, "
+"authoritative players={0}, rooms={1}, stale_epoch_drops={2}, "
+"replay_gaps={3}, epoch_rejects={4}, heartbeat_suspicions={5}, "
 "start_blocked_insufficient_active={6}, start_blocked_missing_ready={7}, "
 "start_blocked_track_not_ready={8}, transport_network_errors={9}, "
 "transport_latency_last_ms={10}, transport_latency_avg_ms={11}, "
 "transport_latency_max_ms={12}, transport_peer_address_changes={13}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Program.Args.cs:90
+#: top_speed_net/TopSpeed.Server/Program.Args.cs
 msgid "debug"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Bots\Setup.cs:50
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Bots/Setup.cs
 msgid "easy"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:276
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 msgid "end_area cannot be empty."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Program.Args.cs:84
+#: top_speed_net/TopSpeed.Server/Program.Args.cs
 msgid "error"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Bots\Setup.cs:51
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Bots/Setup.cs
 msgid "hard"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Program.Args.cs:88
+#: top_speed_net/TopSpeed.Server/Program.Args.cs
 msgid "info"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Online.cs:11
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Online.cs
 msgid "main room"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Runtime\Lifecycle.cs:149
+#: top_speed_net/TopSpeed.Server/Network/Runtime/Lifecycle.cs
 msgid "multiple"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Lifecycle.cs:193
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Lifecycle.cs:253
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Program.Args.cs:78
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Program.Args.cs:92
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Program.cs:45
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Lifecycle.cs
+#: top_speed_net/TopSpeed.Server/Program.Args.cs
+#: top_speed_net/TopSpeed.Server/Program.cs
 msgid "none"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Bots\Setup.cs:52
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Bots/Setup.cs
 msgid "normal"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Input.cs:148
+#: top_speed_net/TopSpeed.Server/Commands/Input.cs
 msgid "off"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Input.cs:147
+#: top_speed_net/TopSpeed.Server/Commands/Input.cs
 msgid "on"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Online.cs:82
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Online.cs
 #, csharp-format
 msgid "room {0}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:147
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 msgid "shutting down..."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Shared\Data\Tracks\Parser\Rules.cs:266
+#: top_speed_net/TopSpeed.Shared/Data/Tracks/Parser/Rules.cs
 msgid "start_area cannot be empty."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Handshake\Protocol.cs:176
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Handshake/Protocol.cs
 msgid "unknown"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Program.Args.cs:86
+#: top_speed_net/TopSpeed.Server/Program.Args.cs
 msgid "warning"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Updates\Runner.cs:268
+#: top_speed_net/TopSpeed.Server/Updates/Runner.cs
 #, csharp-format
 msgid "{0:0.00} GB"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Updates\Runner.cs:272
+#: top_speed_net/TopSpeed.Server/Updates/Runner.cs
 #, csharp-format
 msgid "{0:0.00} KB"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Updates\Runner.cs:270
+#: top_speed_net/TopSpeed.Server/Updates/Runner.cs
 #, csharp-format
 msgid "{0:0.00} MB"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Updates\Runner.cs:273
+#: top_speed_net/TopSpeed.Server/Updates/Runner.cs
 #, csharp-format
 msgid "{0} B"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Control.cs:39
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Control.cs
 #, csharp-format
 msgid "{0} canceled the current game."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Membership\CreateJoin.cs:31
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Membership/CreateJoin.cs
 #, csharp-format
 msgid "{0} created game room {1}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Players\Announcements.cs:14
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Players/Announcements.cs
 #, csharp-format
 msgid "{0} has connected to the server."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Players\Announcements.cs:32
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Players/Announcements.cs
 #, csharp-format
 msgid "{0} has disconnected from the server."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Membership\Leave.cs:73
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Membership/Leave.cs
 #, csharp-format
 msgid "{0} has left the game."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Players\Announcements.cs:31
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Players/Announcements.cs
 #, csharp-format
 msgid "{0} has lost connection to the server."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Host\GameStart.cs:69
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Host/GameStart.cs
 #, csharp-format
 msgid ""
 "{0} is about to start the game. Choose your vehicle and transmission mode."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Lifecycle.cs:33
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Ready.cs:52
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Lifecycle.cs
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Ready.cs
 #, csharp-format
 msgid "{0} is ready."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Ready.cs:98
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Ready.cs
 #, csharp-format
 msgid "{0} left race preparation."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Session\Lifecycle.cs:177
+#: top_speed_net/TopSpeed.Server/Network/Services/Session/Lifecycle.cs
 #, csharp-format
 msgid "{0} lost connection. Waiting for reconnect."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Control.cs:60
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Control.cs
 #, csharp-format
 msgid "{0} paused the current game."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Players.cs:230
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Players.cs
 #, csharp-format
 msgid ""
 "{0} payload mismatch: room={1}, connectionPlayer={2}/{3}, payload={4}/{5}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:137
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 #, csharp-format
 msgid "{0} players are connected:"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Players.cs:244
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Players.cs
 #, csharp-format
 msgid ""
 "{0} race instance mismatch: room={1}, connectionPlayer={2}/{3}, "
 "payloadRaceInstance={4}, roomRaceInstance={5}."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Control.cs:61
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Control.cs
 #, csharp-format
 msgid "{0} resumed the current game."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Room\Messages.cs:41
+#: top_speed_net/TopSpeed.Server/Network/Services/Room/Messages.cs
 #, csharp-format
 msgid "{0} says: {1}"
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Network\Services\Race\Control.cs:133
+#: top_speed_net/TopSpeed.Server/Network/Services/Race/Control.cs
 #, csharp-format
 msgid "{0} stopped the current game."
 msgstr ""
 
-#: D:\top_speed\top_speed_net\TopSpeed.Server\Commands\Host.cs:141
+#: top_speed_net/TopSpeed.Server/Commands/Host.cs
 #, csharp-format
 msgid "{0}, using protocol version {1}"
 msgstr ""


### PR DESCRIPTION
Regenerating the `.pot` templates has been producing thousands of changed lines
that have nothing to do with translation. Two causes, both in the `#:` source
comments:

- **They recorded an absolute path.** xgettext copies each input path straight
  into the comment, and the script passed absolute paths, so the templates ended
  up holding whatever folder the generating machine used. Anyone regenerating on
  a different clone rewrote every comment in the file, which in practice meant
  only whoever generated last could refresh the templates without a huge diff.
- **They recorded a line number.** Any edit that shifted lines rewrote the
  comments for every string below it, even when no translatable text changed.
  That churn also reached the `.po` files, since the comments are carried through
  on each sync, and it came back on every regeneration.

Generate-Templates.ps1 now passes repository-relative, forward-slashed paths
(resolved with `--directory`) and emits locations with `--add-location=file`. A
comment now reads:

    #: top_speed_net/TopSpeed/Menu/Build/Options/Drive.cs

It is identical no matter who runs the script or on which platform, and changes
only when a string is added, removed, or moved to a different file.

## The one-time cost
This first regeneration rewrites every `#:` comment once, and the next sync will
carry the same rewrite into the per-locale `.po` files. That is unavoidable, but
it is the last time: regenerating afterwards produces no diff at all.

**Translations are not affected.** The `.po` files and Crowdin match on `msgid`,
not on the source comments, so nothing is untranslated or fuzzied.

## What else is in the regeneration
Running against current main also picks up the strings from the two recent
merges: the brief and lap/turn readouts, the two new race settings, and the
spoken/tones labels. Those were not in the template yet, so this is what lets
them reach Crowdin.

One string is removed, `"{0}: {1}, {2}, using {3}."` — the old player-info
format that was replaced when it stopped speaking the player number. No other
msgid changes, and the server template's strings are unchanged. Despite adding
18 strings, the client template only grows by 6 lines, since dropping the line
numbers lets repeated strings collapse to a single comment.

## Testing
- Inserted blank lines above a translated string to shift its line number, then
  regenerated: the templates came out byte identical apart from the
  creation-date header.
- Ran the script twice in a row: no changes the second time.
- Ran it under both PowerShell 5.1 and PowerShell 7: identical output.
- Confirmed no strings were lost, and that the build still succeeds.

The two script changes are separate commits, so the path fix can be taken on its
own if the line numbers are worth keeping.
