### PR TITLE
Fix macOS startup deadlock when VoiceOver is running

### DIFF
--- a/top_speed_net/TopSpeed/Program.cs
+++ b/top_speed_net/TopSpeed/Program.cs
@@ -49,6 +49,8 @@ namespace TopSpeed
                            new ClipboardService()))
 #else
                 var window = new WindowHost();
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                    SpeechThreadRuntime.SetDispatcher(new UiThreadSpeechDispatcher());
                 var textInput = new TextInputService(window);
                 using (var app = new GameApp(
                            window,

--- a/top_speed_net/TopSpeed/Window/Eto/UiThreadSpeechDispatcher.cs
+++ b/top_speed_net/TopSpeed/Window/Eto/UiThreadSpeechDispatcher.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Runtime.ExceptionServices;
+using Eto.Forms;
+using TopSpeed.Runtime;
+
+namespace TopSpeed.Windowing.Eto
+{
+    /// <summary>
+    /// Runs screen reader operations on the UI thread. libprism's macOS backends
+    /// marshal their work onto the AppKit main queue with a blocking dispatch when
+    /// called from any other thread, so speech driven from a dedicated worker thread
+    /// deadlocks whenever the main thread is itself waiting on that worker (as it is
+    /// during startup). Invoking on the UI thread lets prism run inline instead.
+    /// </summary>
+    internal sealed class UiThreadSpeechDispatcher : ISpeechThreadDispatcher
+    {
+        public T Invoke<T>(Func<T> action)
+        {
+            if (action == null)
+                throw new ArgumentNullException(nameof(action));
+
+            var application = Application.Instance;
+            if (application == null)
+                return action();
+
+            T result = default!;
+            Exception? error = null;
+            application.Invoke(() =>
+            {
+                try
+                {
+                    result = action();
+                }
+                catch (Exception ex)
+                {
+                    error = ex;
+                }
+            });
+
+            if (error != null)
+                ExceptionDispatchInfo.Capture(error).Throw();
+
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The macOS builds (both x64 and arm64, e.g. v2026.7.28.1) hang forever at launch when VoiceOver is running. The process starts, never speaks, never shows a window, and has to be force-quit. This PR fixes a deadlock between the speech worker thread and the AppKit main thread by running screen-reader operations on the UI thread on macOS, mirroring the existing Android dispatcher pattern.

## Root cause

Two threads end up waiting on each other during startup:

1. **Main thread** — game init runs inside AppKit's `applicationDidFinishLaunching`. It constructs `SpeechService`, whose `ScreenReaderWorker` (in `ThreadMode`, used on all desktop platforms) spins up a dedicated speech thread and then blocks waiting for it: first on `_startupReady.Wait()`, then inside `Invoke(...)` on `completion.Task.GetAwaiter().GetResult()` while `reader.Initialize()` runs on the worker.

2. **Speech worker thread** — `Initialize()` calls into `libprism.dylib`, and prism's VoiceOver backend (`prism_backend_initialize` → `VoiceOverBackend::initialize` → `voiceover_macos_initialize`) marshals its work onto the **AppKit main queue with a blocking dispatch**. Disassembly of the shipped dylib shows the pattern: it checks `NSThread.isMainThread`; if on the main thread it runs inline via `MainActor.assumeIsolated`, otherwise it does `DispatchQueue.main.sync`.

The main thread is blocked waiting on the worker, and the worker is blocked waiting on the main queue that only the main thread can drain. Neither ever proceeds.

This only reproduces when VoiceOver is active (that's when the VoiceOver backend passes the runtime-support check and gets initialized), which is presumably why it slipped through — but it means the mac release hangs at startup for exactly the players an audio game targets.

Captured thread sample of the hung process (v2026.7.28.1, trimmed):

```
Main thread:
  -[NSApplication _sendFinishLaunchingNotification]
  ...
  Monitor_Wait → SyncBlock::Wait → pthread_cond_wait          ← blocked on speech worker

TopSpeed.Speech.ScreenReaderWorker:
  prism_backend_initialize → VoiceOverBackend::initialize
  → voiceover_macos_initialize → DispatchQueue.sync(main)
  → __DISPATCH_WAIT_FOR_QUEUE__                               ← blocked on main thread
```

## Fix

Since prism's macOS backends run inline when already on the main thread and only block-dispatch from other threads, the speech service must drive prism **from** the main thread on macOS — a dedicated worker thread can deadlock any time the main thread waits on a speech call (startup is just the first occurrence; any later main-thread-blocking `Invoke` has the same shape).

`ScreenReaderWorker` already supports exactly this via `DispatcherMode` + `ISpeechThreadDispatcher`, which Android uses. This PR:

- adds `Window/Eto/UiThreadSpeechDispatcher.cs`, an `ISpeechThreadDispatcher` that invokes operations through Eto's `Application.Invoke` (inline when called on the UI thread, marshaled and awaited otherwise), propagating exceptions to the caller;
- registers it in `Program.cs` on macOS only, right after the `WindowHost` (and thus the Eto `Application`) is created.

Windows and Linux keep the current worker-thread behavior; the new file only compiles for the desktop `net10.0` target, and the registration is gated on `RuntimeInformation.IsOSPlatform(OSPlatform.OSX)`.

## Verification

- Reproduced the hang with the released v2026.7.28.1 build (VoiceOver running, Apple Silicon): permanent deadlock with the stacks above.
- Built `osx-arm64` from this branch and launched under identical conditions: startup completes within seconds — `GameLoop` and `AudioUpdate` threads running, no dedicated speech worker thread (dispatcher mode active), no dispatch-wait signatures in a fresh process sample. Menus and speech tested manually.
- No behavior change intended on Windows/Linux/Android/iOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzVjjPKsJjzjwZJsoCMtXV
