### PR TITLE
Fix macOS stuck keys after file dialogs and dead Ctrl+Tab panel switching

### DIFF
--- a/top_speed_net/TopSpeed/TopSpeed.csproj
+++ b/top_speed_net/TopSpeed/TopSpeed.csproj
@@ -132,6 +132,11 @@
     <Compile Remove="Input\Devices\Keyboard\Backends\DirectInput\**\*.cs" />
   </ItemGroup>
 
+  <!-- MacControlTabInterceptor needs MonoMac, which only Eto.Platform.Mac64 provides. -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0' and '$(RuntimeIdentifier)' != 'osx-x64' and '$(RuntimeIdentifier)' != 'osx-arm64'">
+    <Compile Remove="Window\Eto\MacControlTabInterceptor.cs" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-windows'">
     <Compile Remove="AndroidLauncher.cs" />
     <Compile Remove="IOSLauncher.cs" />

--- a/top_speed_net/TopSpeed/Window/Eto/FileDialogService.cs
+++ b/top_speed_net/TopSpeed/Window/Eto/FileDialogService.cs
@@ -32,6 +32,10 @@ namespace TopSpeed.Windowing.Eto
                         selectedPath = dialog.FileName;
                 }
 
+                // The keys that launched the dialog were released while the dialog was
+                // key, so their key-ups never reached the game window; clear them so the
+                // shortcut cannot re-trigger on the next modifier press.
+                _window.ReleaseAllKeys();
                 onCompleted(selectedPath);
             });
         }
@@ -56,6 +60,7 @@ namespace TopSpeed.Windowing.Eto
                         selectedFolder = dialog.Directory;
                 }
 
+                _window.ReleaseAllKeys();
                 onCompleted(selectedFolder);
             });
         }

--- a/top_speed_net/TopSpeed/Window/Eto/MacControlTabInterceptor.cs
+++ b/top_speed_net/TopSpeed/Window/Eto/MacControlTabInterceptor.cs
@@ -1,0 +1,68 @@
+using System;
+using MonoMac.AppKit;
+using MonoMac.Foundation;
+using TopSpeed.Input;
+
+namespace TopSpeed.Windowing.Eto
+{
+    // Cocoa dispatches Control-modified key presses through the key-equivalent chain
+    // (window tabbing, key-view-loop focus navigation) before ordinary key delivery,
+    // which consumes Control+Tab so the game window's keyDown never sees it — plain Tab
+    // arrives fine, Control+Tab does not. A local NSEvent monitor observes every key
+    // event before the app dispatches it, so Control+Tab (and Control+Shift+Tab) can be
+    // translated into game key events here and the original swallowed before Cocoa gets
+    // a chance to eat it.
+    //
+    // This file is compiled only for osx runtime identifiers (see TopSpeed.csproj): it
+    // needs MonoMac, which only Eto.Platform.Mac64 provides. WindowHost locates it by
+    // name via reflection so shared code never references it directly.
+    internal static class MacControlTabInterceptor
+    {
+        private const ushort TabKeyCode = 48;
+
+        private static NSObject? _monitor;
+        private static LocalEventHandler? _handler;
+
+        public static void Install(
+            Func<IntPtr> gameWindowHandle,
+            Func<bool> allowIntercept,
+            Action<InputKey> onKeyDown,
+            Action<InputKey> onKeyUp)
+        {
+            if (_monitor != null)
+                return;
+
+            // Kept in a static so the delegate outlives this call; the monitor holds it
+            // for the lifetime of the process.
+            _handler = theEvent =>
+            {
+                if (theEvent.KeyCode != TabKeyCode)
+                    return theEvent;
+                if ((theEvent.ModifierFlags & NSEventModifierMask.ControlKeyMask) == 0)
+                    return theEvent;
+
+                // Only intercept events destined for the game window; Control+Tab inside
+                // another window (e.g. a file dialog) keeps its native behavior.
+                var handle = gameWindowHandle();
+                var targetWindow = theEvent.Window;
+                if (handle == IntPtr.Zero || targetWindow == null || targetWindow.Handle != handle)
+                    return theEvent;
+                if (!allowIntercept())
+                    return theEvent;
+
+                if (theEvent.Type == NSEventType.KeyDown)
+                    onKeyDown(InputKey.Tab);
+                else if (theEvent.Type == NSEventType.KeyUp)
+                    onKeyUp(InputKey.Tab);
+                else
+                    return theEvent;
+
+                return null!;
+            };
+
+            _monitor = NSEvent.AddLocalMonitorForEventsMatchingMask(
+                NSEventMask.KeyDown | NSEventMask.KeyUp,
+                _handler);
+        }
+    }
+}

--- a/top_speed_net/TopSpeed/Window/Eto/WindowHost.cs
+++ b/top_speed_net/TopSpeed/Window/Eto/WindowHost.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
 using Eto.Drawing;
 using Eto.Forms;
 using TopSpeed.Input;
@@ -52,6 +54,9 @@ namespace TopSpeed.Windowing.Eto
             _root.KeyDown += OnWindowKeyDown;
             _root.KeyUp += OnWindowKeyUp;
             _window.Content = _root;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                TryInstallMacControlTabInterceptor();
         }
 
         public void Run()
@@ -106,7 +111,7 @@ namespace TopSpeed.Windowing.Eto
                 _inputBox.Enabled = true;
                 _root.Content = _inputBox;
                 _textInputActive = true;
-                ReleaseAllModifiers();
+                ReleaseAllKeys();
                 _inputBox.Focus();
             });
         }
@@ -168,8 +173,9 @@ namespace TopSpeed.Windowing.Eto
 
         private void OnWindowKeyUp(object? sender, KeyEventArgs e)
         {
-            if (_textInputActive)
-                return;
+            // Key-ups are processed even while the text input box is active: swallowing
+            // them is how the key that opened the prompt ends up latched down forever in
+            // the event-driven keyboard device.
             EmitKeyUp(e.KeyData);
         }
 
@@ -212,7 +218,7 @@ namespace TopSpeed.Windowing.Eto
 
         private void OnWindowLostFocus(object? sender, EventArgs e)
         {
-            ReleaseAllModifiers();
+            ReleaseAllKeys();
         }
 
         private void EmitKeyDown(Keys keyData)
@@ -227,14 +233,15 @@ namespace TopSpeed.Windowing.Eto
                 KeyUp?.Invoke(key);
         }
 
-        private void ReleaseAllModifiers()
+        // Key-ups delivered while another window is key (a file dialog, the text input
+        // box) never reach this window, so the event-driven keyboard device would keep
+        // those keys latched down forever — and a permanently "held" key re-triggers its
+        // shortcut every time its modifiers come back down. Whenever key-ups may have
+        // gone elsewhere, report every key released so none can stay stuck.
+        internal void ReleaseAllKeys()
         {
-            KeyUp?.Invoke(InputKey.LeftShift);
-            KeyUp?.Invoke(InputKey.RightShift);
-            KeyUp?.Invoke(InputKey.LeftControl);
-            KeyUp?.Invoke(InputKey.RightControl);
-            KeyUp?.Invoke(InputKey.LeftAlt);
-            KeyUp?.Invoke(InputKey.RightAlt);
+            for (var i = 1; i < 256; i++)
+                KeyUp?.Invoke((InputKey)i);
         }
 
         private void InvokeOnUi(Action action)
@@ -272,7 +279,7 @@ namespace TopSpeed.Windowing.Eto
             _inputBox.Visible = false;
             _inputBox.Enabled = false;
             _root.Content = null;
-            ReleaseAllModifiers();
+            ReleaseAllKeys();
         }
 
         private void DisposeInputBoxControl()
@@ -285,6 +292,34 @@ namespace TopSpeed.Windowing.Eto
             _inputBox.KeyUp -= OnInputKeyUp;
             _inputBox.Dispose();
             _inputBox = null;
+        }
+
+        // Cocoa routes Control-modified key presses through the key-equivalent chain
+        // (window tabbing, key-view-loop navigation) before normal key dispatch, so
+        // Control+Tab never reaches this window's KeyDown and panel switching is dead on
+        // macOS. MacControlTabInterceptor sees the event first via a local NSEvent
+        // monitor and feeds it to the game. It is only compiled into osx builds (it needs
+        // MonoMac, which only the Mac Eto platform references), so it is looked up by
+        // name here; on other platforms the lookup finds nothing and this is a no-op.
+        private void TryInstallMacControlTabInterceptor()
+        {
+            try
+            {
+                var type = Type.GetType("TopSpeed.Windowing.Eto.MacControlTabInterceptor");
+                var install = type?.GetMethod("Install", BindingFlags.Public | BindingFlags.Static);
+                install?.Invoke(null, new object[]
+                {
+                    (Func<IntPtr>)(() => NativeHandle),
+                    (Func<bool>)(() => !_textInputActive),
+                    (Action<InputKey>)(key => KeyDown?.Invoke(key)),
+                    (Action<InputKey>)(key => KeyUp?.Invoke(key))
+                });
+            }
+            catch
+            {
+                // Best effort: without the monitor the game still runs, only Control+Tab
+                // stays unavailable because Cocoa consumes it.
+            }
         }
 
         private static string ResolveWindowTitle()


### PR DESCRIPTION
## Summary

Fixes two macOS-only input bugs that made the radio and communicator unusable with a keyboard:

1. **After loading a song with Ctrl+O, almost any subsequent Control chord (VO+arrows, Ctrl+P, …) reopened the Finder file picker.**
2. **Ctrl+Tab / Ctrl+Shift+Tab never switched between the race and radio panels.**

Both are defects in the Eto (macOS/Linux) window layer, not in the game logic or key map — the same game code works correctly on Windows.

## Root causes

**Stuck keys.** The file picker opens on the O key-*down*; the picker then becomes the key window, so the O key-*up* is delivered to the dialog and never reaches the game window. The Eto keyboard backend is purely event-driven (a key stays "down" until a key-up arrives), and the focus-loss safety net in `WindowHost` released only *modifier* keys. Result: the game believed O was held forever. The communicator matches its media shortcuts by *currently-held* state with edge detection, so the instant any fresh Control press arrived (VoiceOver's Ctrl+Option chords, Ctrl+P for play/pause), "Ctrl+O held" became true again and the picker re-fired — before the intended key even registered. Windows is immune because DirectInput polls real hardware state and self-heals a missed key-up.

The text-input path had the same latch: key-ups were swallowed while the chat box was active, so the key that opened the prompt stayed stuck after it closed.

**Ctrl+Tab.** Cocoa dispatches Control-modified key presses through the key-equivalent chain (window tabbing / key-view-loop focus navigation) before ordinary key delivery, and Control+Tab gets consumed there — the content view's `keyDown` never fires. Plain Tab arrives fine (verified in the in-game key mapper), so no game-side mapping change can help; the event has to be captured before Cocoa dispatch.

## Changes

| File | Why |
|---|---|
| `TopSpeed/Window/Eto/WindowHost.cs` | `ReleaseAllModifiers()` → `ReleaseAllKeys()`: releases **all** keys (not just Shift/Ctrl/Alt) on window focus loss and on text-input show/hide, so no key survives a period when key-ups went to another window. Key-ups are no longer dropped while the text input box is active (releases are always safe to process). Adds a reflection bootstrap that installs the Ctrl+Tab interceptor on macOS only. |
| `TopSpeed/Window/Eto/MacControlTabInterceptor.cs` *(new)* | MonoMac local `NSEvent` monitor (`AddLocalMonitorForEventsMatchingMask`) that sees every key event before Cocoa dispatches it. Ctrl+Tab / Ctrl+Shift+Tab destined for the game window are translated into game key events and the originals swallowed so Cocoa can't consume them. Events for other windows (e.g. a file dialog) and the chat text box pass through untouched. |
| `TopSpeed/Window/Eto/FileDialogService.cs` | Belt-and-braces: clears held-key state after either picker closes, before delivering the result — covers any presentation where the focus-loss event doesn't fire. |
| `TopSpeed/TopSpeed.csproj` | Compiles `MacControlTabInterceptor.cs` only for `osx-x64`/`osx-arm64` (it needs MonoMac, which only `Eto.Platform.Mac64` provides). `WindowHost` finds it by name via reflection, so Linux builds don't reference it and behave exactly as before. |

## Testing

- Manually verified on macOS (Apple Silicon, VoiceOver): Ctrl+Tab and Ctrl+Shift+Tab now switch race/radio panels with the proper announcement; after loading a song via Ctrl+O, VO+Left/Right and Ctrl+P no longer reopen the picker (Ctrl+P toggles playback as intended); chat input works and keys behave normally after closing it.
- `dotnet build -c Release -r osx-arm64`: clean, 0 warnings — interceptor confirmed present in the assembly.
- `dotnet build -c Release -r linux-x64`: clean, 0 warnings — confirms the Mac-only file is excluded and the reflection bootstrap is a safe no-op off macOS.
- Windows is untouched: the whole `Window\Eto` tree is already excluded from Windows builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwrUKXmgocgLtsNxPWaM3a