### PR TITLE
macOS: fix screen-reader announcements, key beeps and shutdown

### DIFF
--- a/docs/en/changes.md
+++ b/docs/en/changes.md
@@ -5,6 +5,17 @@ This file tracks new changes to the game for both client and server to make it e
 The game versioning follows a specific pattern by using year.month.day.revision, where revision is an incremental number if there is more than one release in a single day.
 
 
+## Unreleased
+### Game Changes
+- Fixed menu and dialog text being cut short on macOS. A screen used to speak its title or explanation and then name the item you were placed on, and the second announcement cut the first off, so often all you heard was the name of a button. Both are now spoken together, so you hear the whole thing whether or not your screen reader can tell the game when it has finished speaking.
+- Dialogs now read out what they say when they open. Their text could previously only be reached by arrowing down through the dialog, so opening one told you nothing but the name of the default button.
+- Fixed a beep on every key press on macOS. Key presses the game had already dealt with were passed on to the system as well, which answered them with its alert sound, so arrow keys beeped throughout a whole race.
+- Fixed the keyboard going dead on macOS after the media file dialog closed. The game window did not take the keyboard back when the dialog went away, so nothing you pressed afterwards reached the game.
+- Fixed the game not quitting on macOS. Choosing to exit closed the window but left the game running with nothing on screen, and Force Quit was the only way to end it.
+- Fixed Control plus Tab reading your race status out on top of the panel name. Switching between vehicle panels also triggered whatever is bound to Tab on its own, which is the information key by default. Tab on its own is unchanged.
+- Added an "off" choice to the menu sounds setting, for players who would rather hear only their screen reader while moving through the menus.
+
+
 ## 2026.8.3.1
 ### Game Changes
 - Custom vehicles now work in multiplayer races. A room host turns them on with the new "Custom vehicles" game rule, and when another driver picks a vehicle you do not have, your game fetches it from the server by itself. Vehicles are matched by what is inside them rather than by their name, so one you already have is never downloaded, renaming or moving a vehicle does not cause it to download again, and a vehicle you do download arrives only once however many races you use it in. If a vehicle cannot be downloaded or cannot be loaded, the race still starts and you are told which vehicle was unavailable and who was using it.

--- a/top_speed_net/TopSpeed/Input/Drive/Query.cs
+++ b/top_speed_net/TopSpeed/Input/Drive/Query.cs
@@ -90,6 +90,15 @@ namespace TopSpeed.Input
             return _menuNavigationActive && _menuNavigationControllerInputs.Contains(axis);
         }
 
+        // Control+Tab and Control+Shift+Tab switch vehicle panels, and Request info is bound to plain
+        // Tab by default. Drive intents ignore modifiers, so without this the panel shortcut would also
+        // fire whatever is mapped to Tab and read the race status out on top of the panel name. Plain
+        // Tab keeps working; only the panel chord is held back.
+        private bool IsPanelSwitchChord(Key key)
+        {
+            return key == Key.Tab && IsCtrlDown();
+        }
+
         // Edge detection without the overlay guard. Intent evaluation applies its own overlay policy
         // in EvaluateIntentTriggerCore (see IsAllowedDuringOverlay), so whitelisted press intents such
         // as the fuel/tire reports must use this directly; routing them through WasPressed would
@@ -206,6 +215,8 @@ namespace TopSpeed.Input
             if (key == Key.Unknown)
                 return false;
             if (IsInputTrappedByMenu(key))
+                return false;
+            if (IsPanelSwitchChord(key))
                 return false;
 
             var active = meta.KeyboardMode == TriggerMode.Hold

--- a/top_speed_net/TopSpeed/Menu/Build/Helpers.cs
+++ b/top_speed_net/TopSpeed/Menu/Build/Helpers.cs
@@ -28,6 +28,10 @@ namespace TopSpeed.Menu
             }
 
             presets.Sort(StringComparer.OrdinalIgnoreCase);
+
+            // Silence is a valid choice alongside the sound packs on disk: the navigate, wrap and edge
+            // cues talk over the screen reader for players who navigate by speech alone.
+            presets.Insert(0, MenuSoundPresets.Off);
             return presets;
         }
 

--- a/top_speed_net/TopSpeed/Menu/Dialogs/Announcement.cs
+++ b/top_speed_net/TopSpeed/Menu/Dialogs/Announcement.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Text;
 using TopSpeed.Localization;
 
 namespace TopSpeed.Menu
@@ -8,6 +10,27 @@ namespace TopSpeed.Menu
     {
         private static readonly string TitleTemplate = LocalizationService.Mark("{0}  dialog");
         private static readonly string TitleCaptionTemplate = LocalizationService.Mark("{0}  dialog  {1}");
+
+        // Reads the dialog's body lines out as part of the opening announcement. Without this the lines
+        // are only reachable by arrowing through the dialog, so all you hear on open is the button.
+        public static string Compose(string? title, string? caption, IReadOnlyList<DialogItem>? items)
+        {
+            var announcement = Compose(title, caption);
+            if (items == null || items.Count == 0)
+                return announcement;
+
+            var builder = new StringBuilder(announcement);
+            for (var i = 0; i < items.Count; i++)
+            {
+                var line = LocalizationService.Translate(items[i]?.Text);
+                if (string.IsNullOrWhiteSpace(line))
+                    continue;
+
+                builder.Append("  ").Append(line);
+            }
+
+            return builder.ToString();
+        }
 
         public static string Compose(string? title, string? caption)
         {

--- a/top_speed_net/TopSpeed/Menu/Dialogs/Dialog.cs
+++ b/top_speed_net/TopSpeed/Menu/Dialogs/Dialog.cs
@@ -109,7 +109,7 @@ namespace TopSpeed.Menu
             if (updateInPlace)
                 return;
 
-            var announcement = DialogAnnouncement.Compose(dialog.Title, dialog.Caption);
+            var announcement = DialogAnnouncement.Compose(dialog.Title, dialog.Caption, dialog.Items);
             var autoFocus = defaultIndex >= 0;
             _menu.Push(MenuId, announcement, autoFocus ? defaultIndex : null, autoFocus: autoFocus);
         }

--- a/top_speed_net/TopSpeed/Menu/Runtime/Screen/Announce.cs
+++ b/top_speed_net/TopSpeed/Menu/Runtime/Screen/Announce.cs
@@ -47,20 +47,36 @@ namespace TopSpeed.Menu
             CancelHint();
             var opening = _openingAnnouncementOverride ?? Title;
             _openingAnnouncementOverride = null;
-            _waitForTitleSpeechBeforeAutoFocus = !string.IsNullOrWhiteSpace(opening);
-            if (!string.IsNullOrWhiteSpace(opening))
-                _speech.Speak(opening, ResolveTitleSpeakFlag());
-
             _index = NoSelection;
+
             if (_suppressAutoFocus)
             {
                 _suppressAutoFocus = false;
                 ClearAutoFocusPending();
+                SpeakOpening(opening);
+                return;
             }
-            else
-            {
-                QueueAutoFocusFirstItem(force: string.IsNullOrWhiteSpace(opening));
-            }
+
+            QueueAutoFocusFirstItem(force: string.IsNullOrWhiteSpace(opening));
+
+            // Announcing the focused item as a second utterance means it can cut the opening text off
+            // mid-sentence, leaving you with just the button name. Waiting for the first utterance is
+            // not an option: VoiceOver advertises SpeechCapabilities.IsSpeaking but always answers
+            // false, and the timing fallback needs a calibrated rate we do not have yet during setup.
+            // Speaking both as one utterance is the only ordering that holds on every backend.
+            if (_autoFocusPending
+                && !string.IsNullOrWhiteSpace(opening)
+                && TryFocusFirstItemWithOpening(opening))
+                return;
+
+            _waitForTitleSpeechBeforeAutoFocus = !string.IsNullOrWhiteSpace(opening);
+            SpeakOpening(opening);
+        }
+
+        private void SpeakOpening(string opening)
+        {
+            if (!string.IsNullOrWhiteSpace(opening))
+                _speech.Speak(opening, ResolveTitleSpeakFlag());
         }
 
         public void QueueTitleAnnouncement(string? openingAnnouncementOverride = null)

--- a/top_speed_net/TopSpeed/Menu/Runtime/Screen/Audio.cs
+++ b/top_speed_net/TopSpeed/Menu/Runtime/Screen/Audio.cs
@@ -122,6 +122,8 @@ namespace TopSpeed.Menu
         {
             if (string.IsNullOrWhiteSpace(fileName))
                 return null;
+            if (_menuSoundsSilenced)
+                return null;
             var resolvedPath = ResolveMenuSoundPath(fileName);
             if (string.IsNullOrWhiteSpace(resolvedPath))
                 return null;

--- a/top_speed_net/TopSpeed/Menu/Runtime/Screen/Core.cs
+++ b/top_speed_net/TopSpeed/Menu/Runtime/Screen/Core.cs
@@ -54,6 +54,7 @@ namespace TopSpeed.Menu
         private int _hintToken;
         private bool _disposed;
         private string? _menuSoundPresetRoot;
+        private bool _menuSoundsSilenced;
         private bool _titlePending;
         private int _activeActionIndex = NoSelection;
         private string? _openingAnnouncementOverride;
@@ -199,9 +200,12 @@ namespace TopSpeed.Menu
 
         public void SetMenuSoundPreset(string? preset)
         {
-            var root = ResolveMenuSoundPresetRoot(preset);
-            if (string.Equals(_menuSoundPresetRoot, root, StringComparison.OrdinalIgnoreCase))
+            var silenced = MenuSoundPresets.IsOff(preset);
+            var root = silenced ? null : ResolveMenuSoundPresetRoot(preset);
+            if (silenced == _menuSoundsSilenced
+                && string.Equals(_menuSoundPresetRoot, root, StringComparison.OrdinalIgnoreCase))
                 return;
+            _menuSoundsSilenced = silenced;
             _menuSoundPresetRoot = root;
             _menuSoundPathCache.Clear();
             if (_initialized)

--- a/top_speed_net/TopSpeed/Menu/Runtime/Screen/MenuSoundPresets.cs
+++ b/top_speed_net/TopSpeed/Menu/Runtime/Screen/MenuSoundPresets.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace TopSpeed.Menu
+{
+    internal static class MenuSoundPresets
+    {
+        // Preset value that loads no menu cues at all. Stored in settings like any other preset name,
+        // so it round-trips through ui.menuSoundPreset without a separate flag.
+        public const string Off = "off";
+
+        public static bool IsOff(string? preset)
+        {
+            return string.Equals(preset?.Trim(), Off, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/top_speed_net/TopSpeed/Menu/Runtime/Screen/Navigation.cs
+++ b/top_speed_net/TopSpeed/Menu/Runtime/Screen/Navigation.cs
@@ -221,18 +221,71 @@ namespace TopSpeed.Menu
         {
             if (_items.Count == 0)
                 return;
+            _index = TakeFirstFocusIndex();
+            SaveSelectionForActiveView();
+            _activeActionIndex = NoSelection;
+            PlayNavigateSound();
+            AnnounceCurrent(purge: false, SpeechService.SpeakFlag.NoInterrupt);
+            _justEntered = false;
+        }
+
+        // Focuses the first item but folds its text into the screen's opening announcement, so both are
+        // spoken as a single utterance. See AnnounceTitle for why that matters.
+        private bool TryFocusFirstItemWithOpening(string opening)
+        {
+            if (_items.Count == 0)
+                return false;
+
+            var targetIndex = TakeFirstFocusIndex();
+            _index = targetIndex;
+            SaveSelectionForActiveView();
+            _activeActionIndex = NoSelection;
+
+            // No navigate cue: nothing moved. The item is named as part of the opening announcement
+            // rather than being stepped onto.
+            var item = _items[targetIndex];
+            var displayText = item.GetDisplayText();
+
+            // Clear whatever is still being said (a settings confirmation, "Language set to ...") so the
+            // new screen is heard from its first word rather than replacing it halfway through. Screens
+            // that asked for interruptable speech keep their own flag.
+            var flag = ResolveTitleSpeakFlag();
+            if (flag == SpeechService.SpeakFlag.NoInterrupt)
+                flag = SpeechService.SpeakFlag.NoInterruptButStop;
+            _speech.Speak($"{EndOpeningSentence(opening)}  {displayText}", flag);
+            ScheduleHint(item, targetIndex, displayText);
+            _justEntered = false;
+            ClearAutoFocusPending();
+            return true;
+        }
+
+        // Punctuation is what tells a screen reader where to break. Without it the opening text runs
+        // straight into the item name as one clause ("Main menu Race" rather than "Main menu. Race"),
+        // which is the whole reason the two used to be separate utterances. A full stop keeps them
+        // apart while they stay a single Speak call; text that already ends in punctuation is left
+        // alone so nothing is said twice or read out as a stray character.
+        private const string OpeningSentenceEndings = ".!?:;,\u2026\u3002\uFF01\uFF1F\uFF1A\uFF1B\u3001\uFF0C\u061F\u060C";
+
+        private static string EndOpeningSentence(string opening)
+        {
+            var trimmed = opening.TrimEnd();
+            if (trimmed.Length == 0)
+                return trimmed;
+
+            return OpeningSentenceEndings.IndexOf(trimmed[trimmed.Length - 1]) >= 0
+                ? trimmed
+                : trimmed + ".";
+        }
+
+        private int TakeFirstFocusIndex()
+        {
             var targetIndex = 0;
             if (_pendingFocusIndex.HasValue)
                 targetIndex = Math.Max(0, Math.Min(_items.Count - 1, _pendingFocusIndex.Value));
             else if (ActiveView.KeepSelection && ActiveView.SavedSelection != NoSelection)
                 targetIndex = Math.Max(0, Math.Min(_items.Count - 1, ActiveView.SavedSelection));
             _pendingFocusIndex = null;
-            _index = targetIndex;
-            SaveSelectionForActiveView();
-            _activeActionIndex = NoSelection;
-            PlayNavigateSound();
-            AnnounceCurrent(purge: false, SpeechService.SpeakFlag.NoInterrupt);
-            _justEntered = false;
+            return targetIndex;
         }
 
         private bool SwitchScreen(int delta)

--- a/top_speed_net/TopSpeed/Window/Eto/FileDialogService.cs
+++ b/top_speed_net/TopSpeed/Window/Eto/FileDialogService.cs
@@ -36,6 +36,7 @@ namespace TopSpeed.Windowing.Eto
                 // key, so their key-ups never reached the game window; clear them so the
                 // shortcut cannot re-trigger on the next modifier press.
                 _window.ReleaseAllKeys();
+                _window.RestoreGameFocus();
                 onCompleted(selectedPath);
             });
         }
@@ -61,6 +62,7 @@ namespace TopSpeed.Windowing.Eto
                 }
 
                 _window.ReleaseAllKeys();
+                _window.RestoreGameFocus();
                 onCompleted(selectedFolder);
             });
         }

--- a/top_speed_net/TopSpeed/Window/Eto/MacControlTabInterceptor.cs
+++ b/top_speed_net/TopSpeed/Window/Eto/MacControlTabInterceptor.cs
@@ -50,6 +50,14 @@ namespace TopSpeed.Windowing.Eto
                 if (!allowIntercept())
                     return theEvent;
 
+                // What goes into the game is a bare InputKey.Tab: the Control modifier is not carried
+                // along, and the input layer reads Control's state separately from the keyboard. So one
+                // press feeds two consumers at once — the panel switch, which checks IsCtrlDown, and
+                // whatever is bound to plain Tab, which ignores modifiers entirely. That is why the
+                // doubled announcement is a macOS-only fault: on every other platform Control+Tab
+                // reaches the window as one modified key event, while here Cocoa eats the chord and it
+                // only arrives at all by being re-injected through this monitor, stripped of its
+                // modifier. See IsPanelSwitchChord in Input/Drive/Query.cs for the guard.
                 if (theEvent.Type == NSEventType.KeyDown)
                     onKeyDown(InputKey.Tab);
                 else if (theEvent.Type == NSEventType.KeyUp)

--- a/top_speed_net/TopSpeed/Window/Eto/WindowHost.cs
+++ b/top_speed_net/TopSpeed/Window/Eto/WindowHost.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
 using Eto.Drawing;
 using Eto.Forms;
 using TopSpeed.Input;
@@ -11,6 +13,8 @@ namespace TopSpeed.Windowing.Eto
 {
     internal sealed class WindowHost : IWindowHost, IKeyboardEventSource
     {
+        private const int ForcedExitDelayMs = 2000;
+        private int _shutdownStarted;
         private readonly object _textInputLock = new object();
         private readonly Application _application;
         private readonly Form _window;
@@ -64,6 +68,28 @@ namespace TopSpeed.Windowing.Eto
             _application.Run(_window);
         }
 
+        // Puts the keyboard back on the game after another window (a file dialog) has been key.
+        // Without this the game window never regains first responder, so every later key press is
+        // unhandled: macOS plays its alert beep on each arrow key and the game hears nothing.
+        internal void RestoreGameFocus()
+        {
+            InvokeOnUi(() =>
+            {
+                try
+                {
+                    if (!_window.Visible)
+                        return;
+
+                    _window.Focus();
+                    if (!_textInputActive)
+                        _root.Focus();
+                }
+                catch
+                {
+                }
+            });
+        }
+
         public void RequestClose()
         {
             InvokeOnUi(() =>
@@ -75,7 +101,46 @@ namespace TopSpeed.Windowing.Eto
                 catch
                 {
                 }
+
+                // Eto.Mac hides the window but never raises Form.Closed for a programmatic Close(), so
+                // shutdown would never run and the process lingers with no window — the player can then
+                // only end it from Force Quit. Drive the shutdown ourselves instead of waiting for an
+                // event that is not coming.
+                Shutdown();
             });
+        }
+
+        // Runs the close handlers exactly once, whichever way the window went away, then ends the
+        // application. Safe to call from the Eto Closed event and from RequestClose.
+        private void Shutdown()
+        {
+            if (Interlocked.Exchange(ref _shutdownStarted, 1) != 0)
+                return;
+
+            try
+            {
+                Closed?.Invoke();
+            }
+            catch
+            {
+            }
+
+            // Arm the watchdog BEFORE asking the platform to quit: Quit() runs on the UI thread and does
+            // not reliably return here, so anything queued after it would never start. The close
+            // handlers above have already saved and disposed everything, so ending the process is safe.
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(ForcedExitDelayMs).ConfigureAwait(false);
+                Environment.Exit(0);
+            });
+
+            try
+            {
+                (Application.Instance ?? _application).Quit();
+            }
+            catch
+            {
+            }
         }
 
         public void Dispose()
@@ -161,7 +226,7 @@ namespace TopSpeed.Windowing.Eto
 
         private void OnClosed(object? sender, EventArgs e)
         {
-            Closed?.Invoke();
+            Shutdown();
         }
 
         private void OnWindowKeyDown(object? sender, KeyEventArgs e)
@@ -169,6 +234,11 @@ namespace TopSpeed.Windowing.Eto
             if (_textInputActive)
                 return;
             EmitKeyDown(e.KeyData);
+
+            // The game consumed this key. Without marking it handled, Eto forwards the event to the
+            // native view's default keyDown, it walks the responder chain unclaimed, and macOS plays
+            // the alert beep — on every arrow key, all race long.
+            e.Handled = true;
         }
 
         private void OnWindowKeyUp(object? sender, KeyEventArgs e)
@@ -177,6 +247,8 @@ namespace TopSpeed.Windowing.Eto
             // them is how the key that opened the prompt ends up latched down forever in
             // the event-driven keyboard device.
             EmitKeyUp(e.KeyData);
+            if (!_textInputActive)
+                e.Handled = true;
         }
 
         private void OnInputKeyDown(object? sender, KeyEventArgs e)


### PR DESCRIPTION
A batch of macOS/screen-reader fixes found while playing the Eto/macOS build with VoiceOver. Everything here is a fix to existing behaviour except the `off` menu sound preset, which adds a new option.

## macOS window host (`Window/Eto/`)

- **Alert beep on every key press.** `OnWindowKeyDown` / `OnWindowKeyUp` never set `e.Handled`, so Eto forwarded each event to the native view's default `keyDown`; it walked the responder chain unclaimed and macOS played its alert beep — on every arrow key, all race long. The handlers now mark the event handled unless the text input box is active.
- **Keyboard dead after a file dialog.** The game window never regained first responder once `NSOpenPanel` had been key, so no later key press reached the game at all. `FileDialogService` now calls a new `WindowHost.RestoreGameFocus()` after both dialogs.
- **The process never exits.** Eto.Mac hides the window but does not raise `Form.Closed` for a programmatic `Close()`, so the close handlers never ran and the app lingered as a windowless process that could only be ended from Force Quit. Shutdown is now driven from `RequestClose()` too, runs exactly once, and a watchdog calls `Environment.Exit(0)` two seconds after `Quit()` — by then the close handlers have already saved and disposed everything.

## Menu and dialog announcements

- **Opening announcement cut off mid-sentence.** A screen spoke its title and then announced the auto-focused first item as a second utterance, which interrupted the first — often all you heard was the button name. Waiting for the first utterance to finish is not an option here: VoiceOver advertises `SpeechCapabilities.IsSpeaking` but always answers `false`, and the timing fallback needs a calibrated rate that does not exist yet during first-run setup. Title and first item are now spoken as one utterance (`TryFocusFirstItemWithOpening`).
- **Dialog body lines were only reachable by arrowing.** `DialogAnnouncement.Compose` now also takes the dialog's items, so opening a dialog reads its lines out instead of just naming the button.

## In-race input

`Control+Tab` / `Control+Shift+Tab` switch vehicle panels, while `Request info` is bound to plain `Tab` by default. Drive intents ignore modifiers, so the panel shortcut also fired the info report and read the race status out on top of the panel name. Plain `Tab` keeps working; only the panel chord is held back.

## New: `off` menu sound preset

`ui.menuSoundPreset` only chose between the sound packs in `Sounds/menu/1` and `/2`; there was no way to have no menu cues at all. For players who navigate by speech alone, the navigate, wrap and edge cues talk over the screen reader. `off` is inserted at the front of the preset list and `LoadDefaultSound` returns `null` for it, so it round-trips through settings like any other preset name. Happy to drop this part if you would rather not have the option.

## Notes

- Verified with `dotnet build top_speed_net/TopSpeed/TopSpeed.csproj -c Debug -r osx-arm64`. `TopSpeed.Tests` targets `net10.0-windows`, so I could not run the test suite on macOS.

